### PR TITLE
[charts/portal] - Changing the repo for rabbitmq

### DIFF
--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -399,19 +399,19 @@ tenantProvisioner:
 #       topologyKey: "kubernetes.io/hostname"
 
 image:
-  dispatcher: dispatcher:5.0.cr1
-  pssg: pssg:5.0.cr1
-  apim: ingress:5.0.cr1
-  enterprise: portal-enterprise:5.0.cr1
-  data: portal-data:5.0.cr1
-  tps: tenant-provisioning-service:5.0.cr1
-  solr: solr:5.0.cr1
-  analytics: analytics-server:5.0.cr1
-  authenticator: authenticator:5.0.cr1
-  dbUpgrade: db-upgrade-portal:5.0.cr1
-  rbacUpgrade: db-upgrade-rbac:5.0.cr1
-  upgradeVerify: upgrade-verify:5.0.cr1
-  tlsManager: tls-automator:5.0.cr1
+  dispatcher: dispatcher:latest
+  pssg: pssg:latest
+  apim: ingress:latest
+  enterprise: portal-enterprise:latest
+  data: portal-data:latest
+  tps: tenant-provisioning-service:latest
+  solr: solr:latest
+  analytics: analytics-server:latest
+  authenticator: authenticator:latest
+  dbUpgrade: db-upgrade-portal:latest
+  rbacUpgrade: db-upgrade-rbac:latest
+  upgradeVerify: upgrade-verify:latest
+  tlsManager: tls-automator:latest
 
 ##
 ## Subchart Configuration
@@ -637,14 +637,14 @@ druid:
   #         topologyKey: kubernetes.io/hostname
 
   image:
-    zookeeper: zookeeper:5.0.cr1
-    broker: druid:5.0.cr1
-    coordinator: druid:5.0.cr1
-    middlemanager: druid:5.0.cr1
-    minio: minio:5.0.cr1
-    historical: druid:5.0.cr1
-    kafka: kafka:5.0.cr1
-    ingestion: ingestion-server:5.0.cr1
+    zookeeper: zookeeper:latest
+    broker: druid:latest
+    coordinator: druid:latest
+    middlemanager: druid:latest
+    minio: minio:latest
+    historical: druid:latest
+    kafka: kafka:latest
+    ingestion: ingestion-server:latest
 
 # Settings for RabbitMQ - https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq
 rabbitmq:
@@ -653,8 +653,8 @@ rabbitmq:
   fullnameOverride: rabbitmq
   image:
     registry: caapim
-    repository: message-broker-k8s
-    tag: "5.0.cr1"
+    repository: message-broker
+    tag: "latest"
     pullSecrets:
       - broadcom-apim
   serviceAccount:
@@ -712,6 +712,7 @@ rabbitmq:
   extraConfiguration: |-
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
+    disk_free_limit.absolute = 2GB
   resources:
     limits:
       cpu: 1000m

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -328,19 +328,19 @@ tenantProvisioner:
 # affinity: {}
 
 image:
-  dispatcher: dispatcher:5.0.cr1
-  pssg: pssg:5.0.cr1
-  apim: ingress:5.0.cr1
-  enterprise: portal-enterprise:5.0.cr1
-  data: portal-data:5.0.cr1
-  tps: tenant-provisioning-service:5.0.cr1
-  solr: solr:5.0.cr1
-  analytics: analytics-server:5.0.cr1
-  authenticator: authenticator:5.0.cr1
-  dbUpgrade: db-upgrade-portal:5.0.cr1
-  rbacUpgrade: db-upgrade-rbac:5.0.cr1
-  upgradeVerify: upgrade-verify:5.0.cr1
-  tlsManager: tls-automator:5.0.cr1
+  dispatcher: dispatcher:latest
+  pssg: pssg:latest
+  apim: ingress:latest
+  enterprise: portal-enterprise:latest
+  data: portal-data:latest
+  tps: tenant-provisioning-service:latest
+  solr: solr:latest
+  analytics: analytics-server:latest
+  authenticator: authenticator:latest
+  dbUpgrade: db-upgrade-portal:latest
+  rbacUpgrade: db-upgrade-rbac:latest
+  upgradeVerify: upgrade-verify:latest
+  tlsManager: tls-automator:latest
 
 ##
 ## Subchart Configuration
@@ -494,14 +494,14 @@ druid:
   # affinity: {}
 
   image:
-    zookeeper: zookeeper:5.0.cr1
-    broker: druid:5.0.cr1
-    coordinator: druid:5.0.cr1
-    middlemanager: druid:5.0.cr1
-    minio: minio:5.0.cr1
-    historical: druid:5.0.cr1
-    kafka: kafka:5.0.cr1
-    ingestion: ingestion-server:5.0.cr1
+    zookeeper: zookeeper:latest
+    broker: druid:latest
+    coordinator: druid:latest
+    middlemanager: druid:latest
+    minio: minio:latest
+    historical: druid:latest
+    kafka: kafka:latest
+    ingestion: ingestion-server:latest
 
 # Settings for RabbitMQ - https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq
 rabbitmq:
@@ -510,8 +510,8 @@ rabbitmq:
   fullnameOverride: rabbitmq
   image:
     registry: caapim
-    repository: message-broker-k8s
-    tag: "5.0.cr1"
+    repository: message-broker
+    tag: "latest"
     pullSecrets:
       - broadcom-apim
   serviceAccount:
@@ -560,6 +560,7 @@ rabbitmq:
   extraConfiguration: |-
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
+    disk_free_limit.absolute = 2GB
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
**Description of the change**

Changing the repo from message-broker-k8s to message-broker for rabbitmq container which now makes K8s and DS using the same rabbitmq bitnami image.
Adding environment variable - 'disk_free_limit.absolute = 2GB' which syncs with configuration of Disk free limit with DS.
Pointing all the tags to latest.

**Benefits**
This change now makes K8s and DS using the same rabbitmq bitnami image.

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

