### PR TITLE
Develop/gateway - Changes around liquibase command for Java11 SSG image (not yet released)

### DIFF
--- a/examples/otk-scenarios/edge/ssg-single-otk-base-selection-values.yaml
+++ b/examples/otk-scenarios/edge/ssg-single-otk-base-selection-values.yaml
@@ -41,7 +41,7 @@ ssg:
       #       3) Liquibase files to create OTK database schema (/tmp/otk-db-liquibase/)
       - otkBaseSelect1:
         file: OAuthSolutionKit-4.4.1-4425.sskar
-        preInstallCommand: java -jar /tmp/otk-db-liquibase/liquibase-3.2.2.jar --driver=com.mysql.jdbc.Driver --classpath=/opt/SecureSpan/Gateway/runtime/lib/mysql-connector-java-5.1.46.jar --changeLogFile=/tmp/otk-db-liquibase/otk.xml --url="jdbc:mysql://ssg-base-select-otk-mysql:3306/otk_db?createDatabaseIfNotExist=true&useSSL=false" --username=root --password=mypassword update
+        preInstallCommand: java -jar /opt/SecureSpan/Gateway/runtime/lib/liquibase-3.10.1.jar --driver=com.mysql.jdbc.Driver --classpath=/opt/SecureSpan/Gateway/runtime/lib/mysql-connector-java-5.1.46.jar --changeLogFile=/tmp/otk-db-liquibase/otk.xml --url="jdbc:mysql://ssg-base-select-otk-mysql:3306/otk_db?createDatabaseIfNotExist=true&useSSL=false" --username=root --password=mypassword update
         # solutionKitID: b74b063c-5151-4f7d-b4db-71f032cc2d46
         param: --form solutionKitSelectByName="OTK Assertions"
       - otkBaseSelect2:

--- a/examples/otk-scenarios/edge/ssg-single-otk-base-selection-values.yaml
+++ b/examples/otk-scenarios/edge/ssg-single-otk-base-selection-values.yaml
@@ -26,7 +26,7 @@ ssg:
     otkJdbcDriver: com.mysql.jdbc.Driver
     #   - WARNING 1: MySQL deployed by this example is for DEVELOPMENT ONLY OTK database.
     #                For production, an EXTERNALLY managed PERSISTENT deployment is recommended (along with using non-ROOT database/JDBC user).
-    #   - WARNING 2: jdbc url, user & password are also configured elsewhere, search "preInstallCommand: java -jar /tmp/otk-db-liquibase/liquibase"
+    #   - WARNING 2: jdbc url, user & password are also configured elsewhere, search "preInstallCommand: java -jar"
     #   - The host part of jdbc url in this example is determined by the release name used to install. E.g. for "helm install ssg-otk ..." use "ssg-otk-mysql"
     otkJdbcUrl: jdbc:mysql://ssg-base-select-otk-mysql:3306/otk_db
     otkJdbcUser: root

--- a/examples/otk-scenarios/sts/gateway/ssg-sts-values-env-01.yaml
+++ b/examples/otk-scenarios/sts/gateway/ssg-sts-values-env-01.yaml
@@ -55,7 +55,7 @@ ssg:
     otkJdbcDriver: com.mysql.jdbc.Driver
     #   - WARNING 1: MySQL deployed by this example is for DEVELOPMENT ONLY OTK database.
     #                For production, an EXTERNALLY managed PERSISTENT deployment is recommended (along with using non-ROOT database/JDBC user).
-    #   - WARNING 2: jdbc url, user & password are also configured elsewhere, search "preInstallCommand: java -jar /tmp/otk-db-liquibase/liquibase"
+    #   - WARNING 2: jdbc url, user & password are also configured elsewhere, search "preInstallCommand: java -jar"
     #   - The host part of jdbc url in this example is determined by the release name used to install. E.g. for "helm install ssg-otk-internal ..." use "ssg-otk-internal-mysql"
     otkJdbcUrl: jdbc:mysql://####sts-release-name-mysql:3306/otk_db
     # use root credentials for DB Backed STS. Change to 'otk' credentials when using in-memory STS
@@ -70,7 +70,7 @@ ssg:
     #       2) separate install of some OTK sub-solution kits to avoid bug that requires Gateway restart (recommendation from OTK engineering team)
     #       3) Liquibase files to create OTK database schema (/tmp/otk-db-liquibase/)
     - dualGatewayInternalPortal1:
-      preInstallCommand: java -jar /tmp/otk-db-liquibase/liquibase-3.2.2.jar --driver=com.mysql.jdbc.Driver --classpath=/opt/SecureSpan/Gateway/runtime/lib/mysql-connector-java-5.1.46.jar --changeLogFile=/tmp/otk-db-liquibase/otk.xml --url="jdbc:mysql://####sts-release-name-mysql:3306/otk_db?createDatabaseIfNotExist=true&useSSL=false" --username=root --password=mypassword update
+      preInstallCommand: java -jar /opt/SecureSpan/Gateway/runtime/lib/liquibase-3.10.1.jar --driver=com.mysql.jdbc.Driver --classpath=/opt/SecureSpan/Gateway/runtime/lib/mysql-connector-java-5.1.46.jar --changeLogFile=/tmp/otk-db-liquibase/otk.xml --url="jdbc:mysql://####sts-release-name-mysql:3306/otk_db?createDatabaseIfNotExist=true&useSSL=false" --username=root --password=mypassword update
       file: OAuthSolutionKit-4.4.1-4425.sskar
       # solutionKitID: b74b063c-5151-4f7d-b4db-71f032cc2d46
       param: --form solutionKitSelectByName="OTK Assertions"


### PR DESCRIPTION
**Description of the change**

Required changes for Java11 SSG image
- Liquibase version upgrade
- Liquibase command change to use the internal jar due to classpath changes between java8 and java11

**Benefits**

No need for the customer to find their own liquibase.jar and put that into their custom image
Liquibase command works for Java11

**Drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
There are exiting mentions of the /tmp/otk-db-Liquibase dir and the need to add the schema files. That remains unchanged as the liquibase .xml file is still required to come from that dir.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

