### PR TITLE
[charts/portal] NORALLY : Adding RABBITMQ USER Credential to dispatcher container

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.cr1"
 description: CA API Developer Portal
 name: portal
-version: 2.0.5
+version: 2.0.9
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
@@ -47,6 +47,11 @@ spec:
                 name: {{ .Values.tls.externalSecretName }}
                 key: keypass.txt
                 optional: false
+          - name: RABBITMQ_DEFAULT_PASS
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.rabbitmq.auth.secretName }}
+                key: rabbitmq-password
           envFrom:
           - configMapRef:
               name: dispatcher-config

--- a/charts/portal/templates/dispatcher/dispatcher-secret.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-secret.yaml
@@ -9,8 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-{{ if .Values.dispatcher.additionalSecret }}
-{{- range $key, $val := .Values.dispatcher.additionalSecret }}
+  RABBITMQ_DEFAULT_USER: {{ .Values.rabbitmq.auth.username | b64enc | quote }}
+  {{ if .Values.dispatcher.additionalSecret }}
+  {{- range $key, $val := .Values.dispatcher.additionalSecret }}
   {{ $key }}: {{ $val | toString | b64enc }}
-{{- end }}
-{{ end }}
+  {{- end }}
+  {{ end }}

--- a/charts/portal/templates/dispatcher/dispatcher-secret.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-secret.yaml
@@ -10,8 +10,8 @@ metadata:
 type: Opaque
 data:
   RABBITMQ_DEFAULT_USER: {{ .Values.rabbitmq.auth.username | b64enc | quote }}
-  {{ if .Values.dispatcher.additionalSecret }}
+{{ if .Values.dispatcher.additionalSecret }}
   {{- range $key, $val := .Values.dispatcher.additionalSecret }}
   {{ $key }}: {{ $val | toString | b64enc }}
   {{- end }}
-  {{ end }}
+{{ end }}


### PR DESCRIPTION
**Description of the change**
Portal administrator use 'portal health' endpoint to get the status of various services/containers .(https://<portal_domain_name>/portalhealth) , message-broker container/service was not part of this. 
We are adding RABBITMQ USER Credential to dispatcher container , such that we can make message-broker part of portalhealth endpoint.
And it does provides the status as healthy if the container/service doesn't have any alarms and unhealthy otherwise.

**Benefits**

In order to provide administrator a warning or heads-up for message-broker container we are catching memory alarms and disk space alarm for now , and are putting this part of portal health endpoint. 

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

