### PR TITLE
[charts/portal] made db jobs to be preinstall requirement

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.0"
 description: CA API Developer Portal
 name: portal
-version: 2.0.1
+version: 2.0.2
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/templates/jobs/db-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/db-upgrade-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: db-upgrade
   annotations:
     chartversion: {{ .Chart.AppVersion | quote }}
+    "helm.sh/hook": pre-install
   labels:
     app: {{ template "portal.name" . }}
     chart: {{ template "portal.chart" . }}

--- a/charts/portal/templates/jobs/rbac-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/rbac-upgrade-job.yaml
@@ -4,6 +4,7 @@ metadata:
   name: rbac-upgrade
   annotations:
     chartversion: {{ .Chart.AppVersion | quote }}
+    "helm.sh/hook": pre-install
   labels:
     app: {{ template "portal.name" . }}
     chart: {{ template "portal.chart" . }}


### PR DESCRIPTION
**Description of the change**

Requires DB schema to be created before pods startup

**Benefits**

If failure occurs, portal pods would not start until issue is fixed. Otherwise initial tenant seed data can be corrupted 

**Drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

