### PR TITLE
[charts/portal]: update subscription_ttl to 24 hours

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.cr1"
 description: CA API Developer Portal
 name: portal
-version: 2.0.5
+version: 2.0.6
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -712,6 +712,7 @@ rabbitmq:
   extraConfiguration: |-
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
+    mqtt.subscription_ttl = 86400000
   resources:
     limits:
       cpu: 1000m

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -713,6 +713,7 @@ rabbitmq:
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
     mqtt.subscription_ttl = 86400000
+    mqtt.prefetch = 1
   resources:
     limits:
       cpu: 1000m

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -561,6 +561,7 @@ rabbitmq:
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
     mqtt.subscription_ttl = 86400000
+    mqtt.prefetch = 1
   resources:
     limits: {}
     # cpu: 1000m

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -560,6 +560,7 @@ rabbitmq:
   extraConfiguration: |-
     management.load_definitions = /app/load_definition.json
     mqtt.exchange = portal-external
+    mqtt.subscription_ttl = 86400000
   resources:
     limits: {}
     # cpu: 1000m


### PR DESCRIPTION
**Description of the change**

When there are no consumers connected to the queue for ~2 hours and there are no messages being processed in the queue, the queue is currently deleted (observed via Rabbit MQ testing,etc.) This could present issues because deployer is not connected and a message cannot be published.
As a Portal Admin, I want to ensure that all the enrolled Gateways always remain connected with Portal unless the Gateway becomes unavailable.

**Benefits**

A short term fix would be to consider increasing the queue expiry duration to 24 hours to reduce the likelihood of this scenario. 

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

