### PR TITLE
[charts/portal]:APIVersion for ingress-resources of Portal

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.cr1"
 description: CA API Developer Portal
 name: portal
-version: 2.0.7
+version: 2.0.8
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.cr1"
 description: CA API Developer Portal
 name: portal
-version: 2.0.8
+version: 2.0.9
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.type.kubernetes }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: portal-ingress
@@ -21,52 +21,83 @@ spec:
   - host: {{ include "default-tenant-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: dispatcher
-          servicePort: portal-https
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: dispatcher
+            port:
+              name: portal-https
   - host: {{ include "tssg-public-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: apim
-          servicePort: {{ printf "%s-https" .Values.portal.defaultTenantId | quote }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: apim
+            port:
+              name: {{ printf "%s-https" .Values.portal.defaultTenantId | quote }}
   - host: {{ include "analytics-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: apim
-          servicePort: {{ printf "%s-datalake" .Values.portal.defaultTenantId | quote }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: apim
+            port:
+              name: {{ printf "%s-datalake" .Values.portal.defaultTenantId | quote }}
   - host: {{ include "pssg-enroll-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: pssg
-          servicePort: tssg-enroll
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: pssg
+            port:
+              name: tssg-enroll
   - host: {{ include "pssg-sync-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: pssg
-          servicePort: tssg-sync
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: pssg
+            port:
+              name: tssg-sync
   - host: {{ include "pssg-sso-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: apim
-          servicePort: {{ printf "%s-sso" .Values.portal.defaultTenantId | quote }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: apim
+            port:
+              name: {{ printf "%s-sso" .Values.portal.defaultTenantId | quote }}
   - host: {{ include "broker-host" . | quote }}
     http:
       paths:
-      - backend:
-          serviceName: apim
-          servicePort: {{ printf "%s-broker" .Values.portal.defaultTenantId | quote }}
-  
-  {{- range .Values.ingress.tenantIds }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: apim
+            port:
+              name: {{ printf "%s-broker" .Values.portal.defaultTenantId | quote }}
+{{- range .Values.ingress.tenantIds }}
   - host: "{{ . }}.{{ $.Values.portal.domain }}"
     http:
       paths:
-      - backend:
-          serviceName: dispatcher
-          servicePort: portal-https
-    {{- end }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: dispatcher
+            port:
+              name: portal-https
+  {{- end }}
 {{ end }}

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -1,5 +1,10 @@
+{{- $kubeTargetVersion := .Capabilities.KubeVersion.GitVersion }}
 {{ if .Values.ingress.type.kubernetes }}
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
  name: portal-ingress
@@ -21,6 +26,7 @@ spec:
   - host: {{ include "default-tenant-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -28,9 +34,15 @@ spec:
             name: dispatcher
             port:
               name: portal-https
+{{- else }}
+      - backend:
+          serviceName: dispatcher
+          servicePort: portal-https
+{{- end }}
   - host: {{ include "tssg-public-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -38,9 +50,15 @@ spec:
             name: apim
             port:
               name: {{ printf "%s-https" .Values.portal.defaultTenantId | quote }}
+{{- else }}
+      - backend:
+          serviceName: apim
+          servicePort: {{ printf "%s-https" .Values.portal.defaultTenantId | quote }}
+{{- end }}
   - host: {{ include "analytics-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -48,9 +66,15 @@ spec:
             name: apim
             port:
               name: {{ printf "%s-datalake" .Values.portal.defaultTenantId | quote }}
+{{- else }}
+      - backend:
+          serviceName: apim
+          servicePort: {{ printf "%s-datalake" .Values.portal.defaultTenantId | quote }}
+{{- end }}
   - host: {{ include "pssg-enroll-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -58,9 +82,15 @@ spec:
             name: pssg
             port:
               name: tssg-enroll
+{{- else }}
+      - backend:
+          serviceName: pssg
+          servicePort: tssg-enroll
+{{- end }}
   - host: {{ include "pssg-sync-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -68,9 +98,15 @@ spec:
             name: pssg
             port:
               name: tssg-sync
+{{- else }}
+      - backend:
+          serviceName: pssg
+          servicePort: tssg-sync
+{{- end }}
   - host: {{ include "pssg-sso-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -78,9 +114,15 @@ spec:
             name: apim
             port:
               name: {{ printf "%s-sso" .Values.portal.defaultTenantId | quote }}
+{{- else }}
+      - backend:
+          serviceName: apim
+          servicePort: {{ printf "%s-sso" .Values.portal.defaultTenantId | quote }}
+{{- end }}
   - host: {{ include "broker-host" . | quote }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -88,10 +130,16 @@ spec:
             name: apim
             port:
               name: {{ printf "%s-broker" .Values.portal.defaultTenantId | quote }}
+{{- else }}
+      - backend:
+          serviceName: apim
+          servicePort: {{ printf "%s-broker" .Values.portal.defaultTenantId | quote }}
+{{- end }}
 {{- range .Values.ingress.tenantIds }}
   - host: "{{ . }}.{{ $.Values.portal.domain }}"
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
       - pathType: Prefix
         path: "/"
         backend:
@@ -99,5 +147,10 @@ spec:
             name: dispatcher
             port:
               name: portal-https
-  {{- end }}
+{{- else }}
+      - backend:
+          serviceName: dispatcher
+          servicePort: portal-https
+{{- end }}
+{{- end }}
 {{ end }}


### PR DESCRIPTION
**Description of the change**
API version change from v1beta1 to v1 for ingress-resources of Portal. networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress


<!-- Describe the scope of your change - i.e. what the change does. -->
Allows to use latest API version supported in K8s cluster.

**Benefits**
- Avoids warning while installing the helm charts.

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #
  

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)


