### PR TITLE
charts/portal - Changes to support API Portal SaaS 

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -91,6 +91,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `global.legacyHostnames` | Legacy Hostnames | `false` |
 | `global.legacyDatabaseNames` | Legacy Database names | `false` |
 | `global.subdomainPrefix` | Subdomain Prefix | `dev-portal` |
+| `global.helpPage` | Documentation Help Page | `https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/` |
 | `global.storageClass` | Global Storage Class | `_` |
 | `global.schedulerName` | Global Scheduler name for Portal + Analytics, this doesn't apply to other subcharts | `not set` |
 | `global.saas` | Reserved | `not set` |
@@ -174,6 +175,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `apim.affinity` | Affinity for pod assignment  | `{} evaluated as a template` |
 | `authenticator.forceRedeploy` | Force redeployment during helm upgrade whether there is a change or not | `false` |
 | `authenticator.replicaCount` | Number of authenticator nodes | `1` |
+| `authenticator.javaOptions` | Java Options to pass in | `-Xms1g -Xmx1g` |
 | `authenticator.image.pullPolicy` | authenticator image pull policy | `IfNotPresent` |
 | `authenticator.strategy` | Update strategy   | `{} evaluated as a template` |
 | `authenticator.resources` | Resource request/limits   | `{} evaluated as a template` |
@@ -188,6 +190,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `dispatcher.affinity` | Affinity for pod assignment   | `{} evaluated as a template` |
 | `portalData.forceRedeploy` | Force redeployment during helm upgrade whether there is a change or not | `false` |
 | `portalData.replicaCount` | Number of portal data nodes | `1` |
+| `portalData.javaOptions` | Java Options to pass in | `-Xms2g -Xmx2g` |
 | `portalData.image.pullPolicy` | Portal-data image pull policy | `IfNotPresent` |
 | `portalData.strategy` | Update strategy   | `{} evaluated as a template` |
 | `portalData.resources` | Resource request/limits   | `{} evaluated as a template` |
@@ -195,6 +198,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `portalData.affinity` | Affinity for pod assignment   | `{} evaluated as a template` |
 | `portalEnterprise.forceRedeploy` | Force redeployment during helm upgrade whether there is a change or not | `false` |
 | `portalEnterprise.replicaCount` | Number of portal-enterprise nodes | `1` |
+| `portalEnterprise.javaOptions` | Java Options to pass in | `-Xms2g -Xmx2g` |
 | `portalEnterprise.image.pullPolicy` | Portal enterprise image pull policy | `IfNotPresent` |
 | `portalEnterprise.strategy` | Update strategy   | `{} evaluated as a template` |
 | `portalEnterprise.resources` | Resource request/limits   | `{} evaluated as a template` |
@@ -209,12 +213,14 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `pssg.affinity` | Affinity for pod assignment   | `{} evaluated as a template` |
 | `solr.forceRedeploy` | Force redeployment during helm upgrade whether there is a change or not | `false` |
 | `solr.replicaCount` | Number of Solr nodes | `1` |
+| `solr.javaOptions` | Java Options to pass in | `-Xms512m -Xmx512m` |
 | `solr.image.pullPolicy` | Solr image pull policy | `IfNotPresent` |
 | `solr.strategy` | Update strategy   | `{} evaluated as a template` |
 | `solr.resources` | Resource request/limits   | `{} evaluated as a template` |
 | `solr.nodeSelector ` | Node labels for pod assignment   | `{} evaluated as a template` |
 | `tenantProvisioner.forceRedeploy` | Force redeployment during helm upgrade whether there is a change or not | `false` |
 | `tenantProvisioner.replicaCount` | Number of tenant provisioner nodes | `1` |
+| `tenantProvisioner.javaOptions` | Java Options to pass in | `-Xms512m -Xmx512m` |
 | `tenantProvisioner.image.pullPolicy` | Tenant provisioner image pull policy | `IfNotPresent` |
 | `tenantProvisioner.strategy` | Update strategy   | `{} evaluated as a template` |
 | `tenantProvisioner.resources` | Resource request/limits   | `{} evaluated as a template` |

--- a/charts/portal/templates/_helpers.tpl
+++ b/charts/portal/templates/_helpers.tpl
@@ -215,7 +215,11 @@ Get "analytics" database name
 Portal Docops page
 */}}
 {{- define "portal.help.page" -}}
-{{- printf "%s" "https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-0-2/" -}}
+    {{- if .Values.global.helpPage }}
+        {{- printf "%s" .Values.global.helpPage   -}}
+    {{- else }}
+         {{- printf "%s" "https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/" -}}
+    {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/portal/templates/authenticator/authenticator-config.yaml
+++ b/charts/portal/templates/authenticator/authenticator-config.yaml
@@ -20,7 +20,7 @@ data:
   DATABASE_TYPE: {{ required "Please fill in databaseType in values.yaml" .Values.global.databaseType | quote }}
   DATABASE_USE_SSL: {{ .Values.global.databaseUseSSL | quote }}
   DATABASE_REQUIRE_SSL: {{ .Values.global.databaseRequireSSL | quote }}
-  JAVA_OPTIONS: -Xms1024m -Xmx1024m
+  JAVA_OPTIONS: {{ .Values.authenticator.javaOptions | default "-Xms1g -Xmx1g" | quote }}
   NSS_SDB_USE_CACHE: "no"
   PORTAL_VERSION: {{ .Chart.AppVersion }}
   RABBITMQ_PORT: {{ .Values.rabbitmq.service.port | quote }}

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -135,6 +135,24 @@ spec:
           serviceName: apim
           servicePort: {{ printf "%s-broker" .Values.portal.defaultTenantId | quote }}
 {{- end }}
+{{- range .Values.ingress.customRoutes }}
+  - host: "{{ .subdomain }}.{{ $.Values.portal.domain }}"
+    http:
+      paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {{ .service.name }}
+            port:
+              name: {{ .service.port }}
+{{- else }}
+      - backend:
+          serviceName: {{ .service.name }}
+          servicePort: {{ .service.port }}
+{{- end }}
+{{- end }}
 {{- range .Values.ingress.tenantIds }}
   - host: "{{ . }}.{{ $.Values.portal.domain }}"
     http:

--- a/charts/portal/templates/portal-data/portal-data-config.yaml
+++ b/charts/portal/templates/portal-data/portal-data-config.yaml
@@ -25,7 +25,8 @@ data:
   DATABASE_REQUIRE_SSL: {{ .Values.global.databaseRequireSSL | quote }}
   FILE_REPOSITORY_DATABASE_NAME: {{ include "portal-db-name" . | quote }}
   HELP_BASE_URL: {{ include "portal.help.page" . | quote }}
-  # TODO: Find out why this is hardcoded, can it be ommitted?? 
+  JAVA_OPTIONS: {{ .Values.portalData.javaOptions | default "-Xms2g -Xmx2g" | quote }}
+  # TODO: Find out why this is hardcoded, can it be ommitted??
   HOST_NAME_ID: MTAuMTc1LjI0Ny4yNDQgMTcyLjE4LjAuMSAxNzIuMTcuMC4xIAo=
   JAVA_OPTIONS: -Xms2048m -Xmx2048m
   NSS_SDB_USE_CACHE: "no"

--- a/charts/portal/templates/portal-enterprise/portal-enterprise-config.yaml
+++ b/charts/portal/templates/portal-enterprise/portal-enterprise-config.yaml
@@ -21,7 +21,7 @@ data:
   ENTERPRISE_DATABASE_PORT: {{ include "database-port" . | quote }}
   ENTERPRISE_DATABASE_TYPE: {{ required "Please fill in databaseType in values.yaml" .Values.global.databaseType | quote }}
   HELP_BASE_URL: {{ include "portal.help.page" . | quote }}
-  JAVA_OPTIONS: -Xms2048m -Xmx2048m
+  JAVA_OPTIONS: {{ .Values.portalEnterprise.javaOptions | default "-Xms2g -Xmx2g" | quote }}
   NSS_SDB_USE_CACHE: "no"
   PORTAL_VERSION: {{ .Chart.AppVersion }}
   RABBITMQ_HOST: {{ .Values.rabbitmq.host | quote }}

--- a/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
+++ b/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
@@ -134,8 +134,14 @@ spec:
           {{- if .Values.portalEnterprise.resources }}
           resources: {{- toYaml .Values.portalEnterprise.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.global.enableMetricEndpoints }}
           ports:
             - containerPort: 8080
+            - containerPort: 9999
+          {{ else }}
+          ports:
+            - containerPort: 8080
+          {{ end }}
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"

--- a/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
+++ b/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
@@ -137,14 +137,11 @@ spec:
           {{- if .Values.portalEnterprise.resources }}
           resources: {{- toYaml .Values.portalEnterprise.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.global.enableMetricEndpoints }}
           ports:
             - containerPort: 8080
+            {{- if .Values.global.enableMetricEndpoints }}
             - containerPort: 9999
-          {{ else }}
-          ports:
-            - containerPort: 8080
-          {{ end }}
+            {{ end }}
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"

--- a/charts/portal/templates/solr/solr-config.yaml
+++ b/charts/portal/templates/solr/solr-config.yaml
@@ -8,6 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  JAVA_OPTS: -Xms512m -Xmx512m
+  JAVA_OPTIONS: {{ .Values.solr.javaOptions | default "-Xms512m -Xmx512m" | quote }}
   NSS_SDB_USE_CACHE: "no"
   SOLR_PORT: "8983"

--- a/charts/portal/templates/tenant-provisioner/tenant-provisioner-config.yaml
+++ b/charts/portal/templates/tenant-provisioner/tenant-provisioner-config.yaml
@@ -24,7 +24,7 @@ data:
   DATABASE_TYPE: {{ required "Please fill in databaseType in values.yaml" .Values.global.databaseType | quote }}
   DATABASE_USE_SSL: {{ .Values.global.databaseUseSSL | quote }}
   DATABASE_REQUIRE_SSL: {{ .Values.global.databaseRequireSSL | quote }}
-  JAVA_OPTS: -Xms512m -Xmx512m
+  JAVA_OPTIONS: {{ .Values.tenantProvisioner.javaOptions | default "-Xms512m -Xmx512m" | quote }}
   NSS_SDB_USE_CACHE: "no"
   OTK_PORT: {{ .Values.portal.otk.port | quote }}
   PORTAL_VERSION: {{ .Chart.AppVersion }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -20,6 +20,7 @@ global:
   legacyHostnames: false
   legacyDatabaseNames: false
   subdomainPrefix: dev-portal
+  helpPage: https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/
 # storageClass: "_"
 # schedulerName:
 
@@ -208,6 +209,7 @@ apim:
 authenticator:
   forceRedeploy: false
   replicaCount: 2
+  javaOptions: -Xms1g -Xmx1g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -274,6 +276,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 2
+  javaOptions: -Xms2g -Xmx2g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -303,6 +306,7 @@ portalData:
 portalEnterprise:
   forceRedeploy: false
   replicaCount: 2
+  javaOptions: -Xms2g -Xmx2g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -362,6 +366,7 @@ pssg:
 solr:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms512m -Xmx512m
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -381,6 +386,7 @@ solr:
 tenantProvisioner:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms512m -Xmx512m
   image:
     pullPolicy: IfNotPresent
   strategy:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -20,7 +20,8 @@ global:
   legacyHostnames: false
   legacyDatabaseNames: false
   subdomainPrefix: dev-portal
-# storageClass: "_"
+  helpPage: https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/
+  # storageClass: "_"
 # schedulerName:
 # The saas flag should be left as is unless otherwise specified by support.
 # saas: false
@@ -192,6 +193,7 @@ apim:
 authenticator:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms1g -Xmx1g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -240,6 +242,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms2g -Xmx2g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -260,6 +263,7 @@ portalData:
 portalEnterprise:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms2g -Xmx2g
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -300,6 +304,7 @@ pssg:
 solr:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms512m -Xmx512m
   image:
     pullPolicy: IfNotPresent
   strategy:
@@ -319,6 +324,7 @@ solr:
 tenantProvisioner:
   forceRedeploy: false
   replicaCount: 1
+  javaOptions: -Xms512m -Xmx512m
   image:
     pullPolicy: IfNotPresent
   strategy:


### PR DESCRIPTION
**Description of the change**

Changed some items which were required as we moved to SaaS.

- parameterized the helpPage to enable externalizing this value
- parameterized the Java Options for 5 services
- added undocumented feature to enable our SaaS rollout to add custom routes
- added undocumented feature to enable an additional port for PortalEnterprise metrics

**Benefits**

This is primary to support our SaaS deployment.  With these changes, our SaaS helm charts and our publicly distributed helm charts are the same, which is better for everybody.

**Drawbacks**

Anywhere I changed, I added the old default values to prevent this change from impacting customers, unless they changed the helms charts themselves.  There are some undocumented options which we are using for SaaS and should consider for public consumption in the future.

**Applicable issues**
None

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

