### PR TITLE
charts/gateway charts/gateway-otk: 10.1.00 release. Java11. Updated major version for the app

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gateway-otk
-version: 0.0.3
-appVersion: "10.0.00"
+version: 1.0.0
+appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 dependencies:
 - name: hazelcast

--- a/charts/gateway-otk/README.md
+++ b/charts/gateway-otk/README.md
@@ -48,7 +48,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `license.accept`          | Accept Gateway license EULA | `false`  |
 | `image.registry`    | Image Registry               | `docker.io` |
 | `image.repository`          | Image Repository  | `caapim/gateway`  |
-| `image.tag`          | Image tag | `10.0.00`  |
+| `image.tag`          | Image tag | `10.1.00`  |
 | `image.pullPolicy`          | Image Pull Policy | `Always`  |
 | `image.secretName`          | Creates an imagePullSecrets | `nil`  |
 | `image.credentials.username`          | Registry Username | `nil`  |

--- a/charts/gateway-otk/README.md
+++ b/charts/gateway-otk/README.md
@@ -4,6 +4,12 @@ This Chart deploys the API Gateway - OAUTH TOOLKIT with the following `optional`
 
 It's targeted at Gateway v10.x onward.
 
+# Java 11
+
+API Gateway is now running with Java 11 with the release of the v10.1.00. The Gateway-OTK chart's version has been incremented to 1.0.0.
+
+Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well. 
+
 ## This Chart is currently in an alpha state
 Requires a custom Gateway image, more details to follow in the coming weeks.
 

--- a/charts/gateway-otk/README.md
+++ b/charts/gateway-otk/README.md
@@ -4,14 +4,14 @@ This Chart deploys the API Gateway - OAUTH TOOLKIT with the following `optional`
 
 It's targeted at Gateway v10.x onward.
 
+## This Chart is currently in an alpha state
+Requires a custom Gateway image, more details to follow in the coming weeks.
+
 # Java 11
 
 API Gateway is now running with Java 11 with the release of the v10.1.00. The Gateway-OTK chart's version has been incremented to 1.0.0.
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well. 
-
-## This Chart is currently in an alpha state
-Requires a custom Gateway image, more details to follow in the coming weeks.
 
 # Install the Chart
 

--- a/charts/gateway-otk/values.yaml
+++ b/charts/gateway-otk/values.yaml
@@ -9,7 +9,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 10.0.00
+  tag: 10.1.00
   pullPolicy: Always
   # Will create a Registry secret and apply it to the Gateway
   secretName:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "10.0.00"
+appVersion: "10.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 1.0.10
+version: 2.0.0
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `license.accept`          | Accept Gateway license EULA | `false`  |
 | `image.registry`    | Image Registry               | `docker.io` |
 | `image.repository`          | Image Repository  | `caapim/gateway`  |
-| `image.tag`          | Image tag | `10.0.00`  |
+| `image.tag`          | Image tag | `10.1.00`  |
 | `image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `image.secretName`          | Creates an imagePullSecrets | `nil`  |
 | `image.credentials.username`          | Registry Username | `nil`  |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -4,6 +4,11 @@ This Chart deploys the API Gateway with the following `optional` subcharts: haze
 
 It's targeted at Gateway v10.x onward.
 
+# Java 11
+API Gateway is now running with Java 11 with the release of the v10.1.00. The Gateway chart's version has been incremented to 2.0.0.
+
+Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well. 
+
 # Install the Chart
 ```
 $ helm repo add layer7 https://caapim.github.io/apim-charts/

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -9,7 +9,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 10.0.00
+  tag: 10.1.00
   pullPolicy: IfNotPresent
   # Will create a Registry secret and apply it to the Gateway
   secretName:

--- a/examples/otk-scenarios/edge/gateway/ssg-edge-values-env-01.yaml
+++ b/examples/otk-scenarios/edge/gateway/ssg-edge-values-env-01.yaml
@@ -3,7 +3,7 @@ ssg:
   image:
     registry: docker.io
     repository: caapim/gateway
-    tag: 10.0.00
+    tag: 10.1.00
     pullPolicy: Always
     # Will create a Registry secret and apply it to the Gateway
     secretName: ####edge-release-name

--- a/examples/otk-scenarios/sts/gateway/ssg-sts-values-env-01.yaml
+++ b/examples/otk-scenarios/sts/gateway/ssg-sts-values-env-01.yaml
@@ -3,7 +3,7 @@ ssg:
   image:
     registry: docker.io
     repository: caapim/gateway
-    tag: 10.0.00
+    tag: 10.1.00
     pullPolicy: Always
     # Will create a Registry secret and apply it to the Gateway
     secretName: ####sts-release-name


### PR DESCRIPTION
**Description of the change**

10.1.00 Rapier Release which runs on Java11. This is different from 10.0.00 which runs on Java8
docker.io will have 10.1.00
Also increased the major version of the App. 

**Benefits**

Newer release with updated Java and bug fixes within the Layer7 APIM Gateway product

**Drawbacks**

TLSv1.0 and TLSv1.1 is disabled by default due to Java 11.0.11_b9 changes. User can re-enable the disabled algorithm via a change to the java.security file.  

**Applicable issues**

https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-1/release-notes/resolved-issues.html

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

