### PR TITLE
[charts/portal] add cache env for test config

### DIFF
--- a/charts/portal/templates/portal-data/portal-data-deployment.yaml
+++ b/charts/portal/templates/portal-data/portal-data-deployment.yaml
@@ -104,6 +104,11 @@ spec:
                   name: {{ .Values.tls.internalSecretName }}
                   key: keypass.txt
                   optional: false
+            # test only variables
+            - name: RBAC_CLIENT_CACHE_EXPIRY
+              value: "{{ .Values.portalEnterprise.RBAC_CLIENT_CACHE_EXPIRY }}"
+            - name: THEME_CACHE_EXPIRY
+              value: "{{ .Values.portalEnterprise.THEME_CACHE_EXPIRY }}"
           envFrom:
           - configMapRef:
               name: portal-data-config

--- a/charts/portal/templates/portal-data/portal-data-deployment.yaml
+++ b/charts/portal/templates/portal-data/portal-data-deployment.yaml
@@ -106,9 +106,9 @@ spec:
                   optional: false
             # test only variables
             - name: RBAC_CLIENT_CACHE_EXPIRY
-              value: "{{ .Values.portalEnterprise.RBAC_CLIENT_CACHE_EXPIRY }}"
+              value: "{{ .Values.portalData.RBAC_CLIENT_CACHE_EXPIRY }}"
             - name: THEME_CACHE_EXPIRY
-              value: "{{ .Values.portalEnterprise.THEME_CACHE_EXPIRY }}"
+              value: "{{ .Values.portalData.THEME_CACHE_EXPIRY }}"
           envFrom:
           - configMapRef:
               name: portal-data-config

--- a/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
+++ b/charts/portal/templates/portal-enterprise/portal-enterprise-deployment.yaml
@@ -113,6 +113,11 @@ spec:
                   name: {{ .Values.tls.internalSecretName }}
                   key: keypass.txt
                   optional: false
+            # test only variables
+            - name: RBAC_CLIENT_CACHE_EXPIRY
+              value: "{{ .Values.portalEnterprise.RBAC_CLIENT_CACHE_EXPIRY }}"
+            - name: THEME_CACHE_EXPIRY
+              value: "{{ .Values.portalEnterprise.THEME_CACHE_EXPIRY }}"
           envFrom:
           - configMapRef:
               name: portal-enterprise-config


### PR DESCRIPTION
**Description of the change**
adds cache env for test configs

**Benefits**
for testing purpose

**Drawbacks**
none

**Applicable issues**
none

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

