### PR TITLE
[charts/portal] Scaling solr to 0 to mitigate log4j vulnerabilities

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.0.2"
 description: CA API Developer Portal
 name: portal
-version: 2.1.1
+version: 2.1.2
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -353,7 +353,7 @@ pssg:
 
 
 solr:
-  replicaCount: 1
+  replicaCount: 0
   image:
     pullPolicy: IfNotPresent
   strategy:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -291,7 +291,7 @@ pssg:
 # affinity: {}
 
 solr:
-  replicaCount: 1
+  replicaCount: 0
   image:
     pullPolicy: IfNotPresent
   strategy:


### PR DESCRIPTION
**Description of the change**

Scaling solr to 0 to mitigate log4j vulnerability

**Benefits**

no vulnerability for log4j

**Drawbacks**

autosuggest won't be available for search

**Applicable issues**

DE523193: CVE-2021-44228 log4j 

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

