### PR TITLE
[charts/portal] MySQL InPlace upgrade from 5.7 to 8.0.26

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.1.0"
 description: CA API Developer Portal
 name: portal
-version: 2.1.11
+version: 2.1.13
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -14,7 +14,7 @@ This Chart deploys the Layer7 API Developer Portal on a Kubernetes Cluster using
 Solutions & Patches](https://techdocs.broadcom.com/us/product-content/recommended-reading/technical-document-index/ca-api-developer-portal-solutions-and-patches.html)
 
 ### Production
-- A dedicated MySQL 8.0.22/8.0.26 server [TechDocs](https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/configure-an-external-database.html)
+- A dedicated MySQL 8.0.22/8.0.26 server [TechDocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/configure-an-external-database.html)
 - 3 Worker nodes with at least 4vcpu and 32GB ram - High Availability with analytics
 - Access to a DNS Server
 - Signed SSL Server Certificate

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -64,30 +64,35 @@ MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1+. This
 
 Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
+
 Persist Analytics Data into Druid Database
 ```
  Connect the coordinator pod(s) and run below com
  $ kubectl exec -it coordinator-0|1 -n <namespace> sh
+
  Run the following curl command to persists Analytics data
  $ curl --location --request POST 'localhost:8081/druid/indexer/v1/supervisor/terminateAll'
+
  Run the below curl commands and wait until the runningTasks response is empty and the supervisor response is empty before proceeding with other steps.
  $ curl localhost:8081/druid/indexer/v1/runningTasks
  $ curl localhost:8081/druid/indexer/v1/supervisor
 ```
 
+
 Stop the Running portal
 ```
  Get the Release name
  $ helm list -n <namespace>
+
  Uninstall the chart
  $ helm uninstall <release name> -n <namespace>
 ```
 
 Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
-Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26
+Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26.
+Ensure in ***values.yaml** the value of tls.job.enabled must be set to **false**
 ```
- Before starting of portal to use the upgraded MySQL, ensure in **values.yaml** the value of tls.job.enabled must be set to **false**
  Use the older release name and Install the chart 
  $ helm install <release name> -n <namespace>
 ```

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -60,7 +60,7 @@ To delete API Portal installation
 *Additional resources such as PVCs and Secrets will need to be cleaned up manually. This protects your data in the event of an accidental deletion.* 
 
 ## Upgrade External Portal Database to MySQL 8.0
-MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1+. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
+MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
 
 Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -83,11 +83,11 @@ Stop the Running portal
  $ helm uninstall <release name> -n <namespace>
 ```
 
-Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - Perform the Upgrade (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
-Once MySQL upgrade is done and ensuring we could connect to it, start the portal with MySQL 8.0.26
+Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26
 ```
- Before starting portal Install with upgraded MySQL, ensure in **values.yaml** the value of tls.job.enabled must be set to **false**
+ Before starting of portal to use the upgraded MySQL, ensure in **values.yaml** the value of tls.job.enabled must be set to **false**
  Use the older release name and Install the chart 
  $ helm install <release name> -n <namespace>
 ```

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -78,7 +78,6 @@ Persist Analytics Data into Druid Database
  $ curl localhost:8081/druid/indexer/v1/supervisor
 ```
 
-
 Stop the Running portal
 ```
  Get the Release name
@@ -91,7 +90,7 @@ Stop the Running portal
 Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26.
-Ensure in ***values.yaml** the value of tls.job.enabled must be set to **false**
+Ensure in **values.yaml** the value of **tls.job.enabled** must be set to **false**
 ```
  Use the older release name and Install the chart 
  $ helm install <release name> -n <namespace>

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -14,7 +14,7 @@ This Chart deploys the Layer7 API Developer Portal on a Kubernetes Cluster using
 Solutions & Patches](https://techdocs.broadcom.com/us/product-content/recommended-reading/technical-document-index/ca-api-developer-portal-solutions-and-patches.html)
 
 ### Production
-- A dedicated MySQL 5.7/8.0.22 server [TechDocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-0-2/install-configure-and-upgrade/install-portal-on-docker-swarm/configure-an-external-database.html#concept.dita_18bc57ed503d5d7b08bde9b6e90147aef9a864c4_ProvideMySQLSettings)
+- A dedicated MySQL 8.0.22/8.0.26 server [TechDocs](https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/configure-an-external-database.html)
 - 3 Worker nodes with at least 4vcpu and 32GB ram - High Availability with analytics
 - Access to a DNS Server
 - Signed SSL Server Certificate
@@ -58,6 +58,39 @@ To delete API Portal installation
 ```
 
 *Additional resources such as PVCs and Secrets will need to be cleaned up manually. This protects your data in the event of an accidental deletion.* 
+
+## Upgrade External Portal Database to MySQL 8.0
+MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1+. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
+
+Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+
+Persist Analytics Data into Druid Database
+```
+ Connect the coordinator pod(s) and run below com
+ $ kubectl exec -it coordinator-0|1 -n <namespace> sh
+ Run the following curl command to persists Analytics data
+ $ curl --location --request POST 'localhost:8081/druid/indexer/v1/supervisor/terminateAll'
+ Run the below curl commands and wait until the runningTasks response is empty and the supervisor response is empty before proceeding with other steps.
+ $ curl localhost:8081/druid/indexer/v1/runningTasks
+ $ curl localhost:8081/druid/indexer/v1/supervisor
+```
+
+Stop the Running portal
+```
+ Get the Release name
+ $ helm list -n <namespace>
+ Uninstall the chart
+ $ helm uninstall <release name> -n <namespace>
+```
+
+Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - Perform the Upgrade (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+
+Once MySQL upgrade is done and ensuring we could connect to it, start the portal with MySQL 8.0.26
+```
+ Before starting portal Install with upgraded MySQL, ensure in **values.yaml** the value of tls.job.enabled must be set to **false**
+ Use the older release name and Install the chart 
+ $ helm install <release name> -n <namespace>
+```
 
 ## Additional Guides/Info
 * [Use/Replace Signed Certificates](#certificates)

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -62,7 +62,7 @@ To delete API Portal installation
 ## Upgrade External Portal Database to MySQL 8.0
 MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
 
-Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from [TechDocs] (https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from [TechDocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 
 Persist Analytics Data into Druid Database
@@ -87,7 +87,7 @@ Stop the Running portal
  $ helm uninstall <release name> -n <namespace>
 ```
 
-Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** [TechDocs] (https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** [TechDocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26.
 Ensure in **values.yaml** the value of **tls.job.enabled** must be set to **false**

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -62,7 +62,7 @@ To delete API Portal installation
 ## Upgrade External Portal Database to MySQL 8.0
 MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
 
-Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from [TechDocs] (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 
 Persist Analytics Data into Druid Database
@@ -87,7 +87,7 @@ Stop the Running portal
  $ helm uninstall <release name> -n <namespace>
 ```
 
-Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** [TechDocs] (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26.
 Ensure in **values.yaml** the value of **tls.job.enabled** must be set to **false**

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -62,7 +62,7 @@ To delete API Portal installation
 ## Upgrade External Portal Database to MySQL 8.0
 MySQL 8.0 is supported as external database starting from Portal 5.0 CR 1. This section helps you understand the overall process of upgrading an existing Portal database running MySQL 5.7 to MySQL 8.0.
 
-Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from [TechDocs] (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Before starting upgrade of Database follow the sections **Before You Begin** and **Check Database Compatibility** from [TechDocs] (https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 
 Persist Analytics Data into Druid Database
@@ -87,7 +87,7 @@ Stop the Running portal
  $ helm uninstall <release name> -n <namespace>
 ```
 
-Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** [TechDocs] (https://techdocs-author.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
+Upgrade MYSQL 5.7 to 8.0.26 using the steps available at section - **Perform the Upgrade** [TechDocs] (https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-1/install-configure-and-upgrade/install-portal-on-docker-swarm/upgrade-portal-database-to-mysql-8.html)
 
 Once MySQL upgrade is done, ensure we could connect to it and then follow below steps to start the portal with MySQL 8.0.26.
 Ensure in **values.yaml** the value of **tls.job.enabled** must be set to **false**


### PR DESCRIPTION
**Description of the change**
Added documentation for upgrading MySQL 5.7 to 8.0.26

**Benefits**
Portal supported OnPremise MySQL Database upgrade steps are documented 

**Drawbacks**
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

