### PR TITLE
[Charts/gateway and Charts/gateway-otk] Bumping the versions to merge the develop/portal to stable

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 1.0.1
+version: 1.0.2
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 dependencies:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 2.0.2
+version: 2.0.3
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:


### PR DESCRIPTION
**Description of the change**

- This version upgrade is to get out of the lint errors that are based out of CT  tool tied for this repository.
- Script that fails the CT job is apim-charts/.github/version-check.sh 

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

