### PR TITLE
Portal/jobs tolerations

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.1.0"
 description: CA API Developer Portal
 name: portal
-version: 2.2.0
+version: 2.2.1
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -299,6 +299,8 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `tenantProvisioner.tolerations`      | Pod tolerations for pod assignment                           | `{} evaluated as a template`                                 |
 | `tenantProvisioner.affinity `        | Affinity for pod assignment                                  | `{} evaluated as a template`                                 |
 | `tenantProvisioner.additionalLabels` | A list of custom key: value labels                           | `not set`                                                    |
+| `jobs.nodeSelector`                  | Node labels for pod assignment                               | `{} evaluated as a template`                                 |
+| `jobs.tolerations`                   | Pod tolerations for pod assignment                           | `{} evaluated as a template`                                 |
 
 
 ### RBAC Parameters

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -167,7 +167,6 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `portal.ssoDebug` | SSO Debugging | `false` |
 | `portal.hostnameWhiteList` | Hostname whitelist | `` |
 | `portal.defaultTenantId` | **Important!** Do not change the default tenant ID unless you have been using a different tenant ID in your previous install/deployment. There is a 15 character limit. See [DNS Configuration](#dns-configuration) for tenant ID character limitations.  | `apim` |
-| `portal.jobsLabels` | A list of custom key: value labels applied to jobs | `not set` |
 | `portal.registryCredentials` | Used to create image pull secret, see prerequisites | `` |
 | `portal.useExistingPullSecret` | Configures Portal Deployment to use **global.pullSecret** as imagePullSecret | `false` |
 | `portal.imagePullSecret.enabled` | Configures Portal Deployment to use custom registry, this option is only evaluated only when portal.registryCredentials option is not used | `false` |
@@ -301,6 +300,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `tenantProvisioner.additionalLabels` | A list of custom key: value labels                           | `not set`                                                    |
 | `jobs.nodeSelector`                  | Node labels for pod assignment                               | `{} evaluated as a template`                                 |
 | `jobs.tolerations`                   | Pod tolerations for pod assignment                           | `{} evaluated as a template`                                 |
+| `jobs.labels`                        | A list of custom key: value labels applied to jobs           | `not set` |
 
 
 ### RBAC Parameters

--- a/charts/portal/templates/jobs/cert-update-job.yaml
+++ b/charts/portal/templates/jobs/cert-update-job.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- range $key, $val := .Values.global.additionalLabels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
-    {{- range $key, $val := .Values.portal.jobsLabels }}
+    {{- range $key, $val := .Values.jobs.labels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
 spec:

--- a/charts/portal/templates/jobs/cert-update-job.yaml
+++ b/charts/portal/templates/jobs/cert-update-job.yaml
@@ -91,4 +91,7 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.tolerations }}
+      tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
+      {{- end }}
 {{- end }}

--- a/charts/portal/templates/jobs/cert-update-job.yaml
+++ b/charts/portal/templates/jobs/cert-update-job.yaml
@@ -91,6 +91,9 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 12 }}
+      {{- end }}
       {{- if .Values.jobs.tolerations }}
       tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
       {{- end }}

--- a/charts/portal/templates/jobs/db-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/db-upgrade-job.yaml
@@ -60,6 +60,9 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 12 }}
+      {{- end }}
       {{- if .Values.jobs.tolerations }}
       tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
       {{- end }}

--- a/charts/portal/templates/jobs/db-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/db-upgrade-job.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- range $key, $val := .Values.global.additionalLabels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
-    {{- range $key, $val := .Values.portal.jobsLabels }}
+    {{- range $key, $val := .Values.jobs.labels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
 spec:

--- a/charts/portal/templates/jobs/db-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/db-upgrade-job.yaml
@@ -60,4 +60,7 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.tolerations }}
+      tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
+      {{- end }}
       restartPolicy: "OnFailure"

--- a/charts/portal/templates/jobs/rbac-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/rbac-upgrade-job.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- range $key, $val := .Values.global.additionalLabels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
-    {{- range $key, $val := .Values.portal.jobsLabels }}
+    {{- range $key, $val := .Values.jobs.labels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
 spec:

--- a/charts/portal/templates/jobs/rbac-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/rbac-upgrade-job.yaml
@@ -58,4 +58,7 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.tolerations }}
+      tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
+      {{- end }}
       restartPolicy: "OnFailure"

--- a/charts/portal/templates/jobs/rbac-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/rbac-upgrade-job.yaml
@@ -58,6 +58,9 @@ spec:
       imagePullSecrets:
       - name: "{{ .Values.global.pullSecret }}"
       {{- end }}
+      {{- if .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 12 }}
+      {{- end }}
       {{- if .Values.jobs.tolerations }}
       tolerations: {{- toYaml .Values.jobs.tolerations | nindent 12 }}
       {{- end }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -797,6 +797,7 @@ ingress-nginx:
 
 #Settings for portal jobs
 jobs:
+  labels: {}
 # nodeSelector: {}
 # tolerations: []
 

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -795,7 +795,7 @@ ingress-nginx:
 #  tcp:
 #    9443: "<namespace>/dispatcher:9443"
 
-#Settings for portal jobs
+# Settings for portal jobs
 jobs:
   labels: {}
 # nodeSelector: {}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -795,6 +795,12 @@ ingress-nginx:
 #  tcp:
 #    9443: "<namespace>/dispatcher:9443"
 
+#Settings for portal jobs
+jobs:
+# nodeSelector: {}
+# tolerations: []
+
+
 # We recommend that MySQL is externalised, the default implementation here is for reference only and is NOT suitable for use
 # in any production environment.
 # We recommend that MySQL is externalised, the default implementation here is for reference only and is NOT suitable for use

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -644,6 +644,7 @@ ingress-nginx:
 
 #Settings for portal jobs
 jobs:
+  labels: {}
   # nodeSelector: {}
   # tolerations: []
 

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -642,7 +642,7 @@ ingress-nginx:
 #  tcp:
 #    9443: "<namespace>/dispatcher:9443"
 
-#Settings for portal jobs
+# Settings for portal jobs
 jobs:
   labels: {}
   # nodeSelector: {}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -642,6 +642,11 @@ ingress-nginx:
 #  tcp:
 #    9443: "<namespace>/dispatcher:9443"
 
+#Settings for portal jobs
+jobs:
+  # nodeSelector: {}
+  # tolerations: []
+
 # We recommend that MySQL is externalised, the default implementation here is for reference only and is NOT suitable for use
 # in any production environment.
 # MySQL Stable Chart values - https://github.com/bitnami/charts/tree/master/bitnami/mysql


### PR DESCRIPTION
**Description of the change**

Added option to configure tolerations and nodeSelector for jobs 

**Benefits**

pods that execute jobs would have option to have tolerations and nodeSelector configurations

**Drawbacks**

n/a

**Applicable issues**

n/a

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

