### PR TITLE
charts/gateway 2.0.4 update

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 2.0.3
+version: 2.0.4
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -13,6 +13,17 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
 - MySQL Stable Chart is deprecated - the demo database subChart has been changed to Bitnami MySQL - if your database is NOT externalised you will lose any policy/configuration you have there.
 - tls.customKey ==> tls.useSignedCertificates tls.key tls.pass tls.existingSecretName
 
+## 2.0.4 Updates to Secret Management
+- Added support for the Kubernetes CSI Driver for gateway bundles. This does not currently extend to environment variables or the Gateway license.
+- The CSI functionality is optional
+
+## 2.0.4 General Updates
+- Added support for sidecars and initContainers
+  - volumeMounts are automatically configured with emptyDir 
+- Updated default values update to reflect empty objects/arrays for optional fields.
+- Load the Gateway Deployment's ServiceAccountToken as a stored password for querying the Kubernetes API.
+  - management.kubernetes.loadServiceAccountToken
+
 ## 2.0.2 Updates to Secret Management
 - You can now specify existing secrets for Gateway Configuration, DefaultSSLKey (tls) and bundles
 
@@ -96,6 +107,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `management.restman.enabled`          | Enable/Disable the Rest Management API (Restman) | `false`  |
 | `management.username`          | Policy Manager Username | `admin`  |
 | `management.password`          | Policy Manager Password | `mypassword`  |
+| `management.kubernetes.loadServiceAccountToken`    | Automatically load the Gateway Deployment's ServiceAccount Token for querying the Kubernetes API | `false`  |
 | `database.enabled`          | Run in DB Backed or Ephemeral Mode | `true`  |
 | `database.create`          | Deploy the MySQL stable deployment as part of this release | `true`  |
 | `database.username`          | Database Username | `gateway`  |
@@ -123,8 +135,8 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `bundle.enabled`          | Creates a configmap with bundles from the ./bundles folder | `false`  |
 | `bundle.path`          | Specify the path to the bundle files. The bundles folder in this repo has some example bundle files | `"bundles/*.bundle"`  |
 | `existingBundle.enabled`          | Enable mounting existing configMaps/Secrets that contain Layer7 Gateway Bundles - see values.yaml for more info | `false`  |
-| `existingBundle.configMaps`          | Array of configMap names that will be mounted to the Gateway's bootstrap folder | `see values.yaml`  |
-| `existingBundle.secrets`          | Array of Secret names that will be mounted to the Gateway's bootstrap folder  | `see values.yaml`  |
+| `existingBundle.configMaps`          | Array of configMaps that will be mounted to the Gateway's bootstrap folder | `see values.yaml`  |
+| `existingBundle.secrets`          | Array of Secrets that will be mounted to the Gateway's bootstrap folder  | `see values.yaml`  |
 | `customHosts.enabled`          | Enable customHosts on the Gateway, this overrides /etc/hosts.  | `see values.yaml`  |
 | `customHosts.hostAliases`          | Array of hostAliases to add to the Container Gateway  | `see values.yaml`  |
 | `service.type`    | Service Type               | `LoadBalancer` |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -61,3 +61,42 @@ data:
     com.l7tech.server.extension.sharedClusterInfoProvider=ssgdb
 {{ .Values.config.systemProperties | indent 4 }}
 {{ end }}
+{{ if .Values.management.kubernetes.loadServiceAccountToken}}
+  002-load-service-account-token: |-
+    #!/bin/bash
+    SERVICE_ACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+    UPDATE_SERVICE_ACCOUNT_TOKEN=$(sed -e "s~SERVICE_ACCOUNT_TOKEN~${SERVICE_ACCOUNT_TOKEN}~g" /opt/docker/rc.d/base/update-service-account-token.xml)
+    echo "${UPDATE_SERVICE_ACCOUNT_TOKEN}" > ${GATEWAY_DIR}/node/default/etc/bootstrap/bundle/02_update_service_account_token.xml.req.bundle
+  update-service-account-token: |-
+    <?xml version="1.0" encoding="UTF-8"?>
+    <l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+        <l7:References>
+            <l7:Item>
+                <l7:Name>sa_token</l7:Name>
+                <l7:Id>fc8324c4f9f6221a79ce132b3a4052d5</l7:Id>
+                <l7:Type>SECURE_PASSWORD</l7:Type>
+                <l7:Resource>
+                    <l7:StoredPassword id="fc8324c4f9f6221a79ce132b3a4052d5">
+                        <l7:Name>sa_token</l7:Name>
+                        <l7:Password>SERVICE_ACCOUNT_TOKEN</l7:Password>
+                        <l7:Properties>
+                            <l7:Property key="description">
+                                <l7:StringValue>Kubernetes Service Account Token</l7:StringValue>
+                            </l7:Property>
+                            <l7:Property key="type">
+                                <l7:StringValue>Password</l7:StringValue>
+                            </l7:Property>
+                            <l7:Property key="usageFromVariable">
+                                <l7:BooleanValue>true</l7:BooleanValue>
+                            </l7:Property>
+                        </l7:Properties>
+                    </l7:StoredPassword>
+                </l7:Resource>
+            </l7:Item>
+        </l7:References>
+        <l7:Mappings>
+            <l7:Mapping action="NewOrUpdate" srcId="fc8324c4f9f6221a79ce132b3a4052d5" type="SECURE_PASSWORD">
+            </l7:Mapping>
+        </l7:Mappings>
+    </l7:Bundle>
+{{ end }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -30,11 +30,17 @@ spec:
       {{- if .Values.global.schedulerName }}
       schedulerName: {{ .Values.global.schedulerName }}
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- toYaml .Values.initContainers | nindent 12 }}
+      {{- end }}
 {{ if .Values.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: {{ template "gateway.imagePullSecret" . }}
 {{ end }}
       containers:
+        {{ if .Values.sidecars }}
+        {{- toYaml .Values.sidecars | nindent 8 }}
+        {{ end }}
         - name: {{ .Chart.Name }}
           image: {{.Values.image.registry}}/{{.Values.image.repository}}:{{.Values.image.tag}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -101,15 +107,47 @@ spec:
 {{ end }}
 {{ if .Values.existingBundle.enabled }}
            {{- range .Values.existingBundle.configMaps }}
-            - name: {{ . }}
-              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/{{ . }}
+            - name: {{ .name }}
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/{{ .name }}
            {{- end }}
            {{- range .Values.existingBundle.secrets }}
-            - name: {{ . }}
-              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/{{ . }}
+            - name: {{ .name }}
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/{{ .name }}
+              {{ if .csi }}
+              readOnly: {{ .csi.readOnly }}
+              {{ end }}
            {{- end }}
 {{ end }}
-
+{{ if .Values.management.kubernetes.loadServiceAccountToken }}
+            - name: {{ template "gateway.fullname" . }}-service-account-token-script
+              mountPath: /opt/docker/rc.d/002-load-service-account-token.sh
+              subPath: 002-load-service-account-token.sh
+            - name: {{ template "gateway.fullname" . }}-service-account-token-template
+              mountPath: /opt/docker/rc.d/base/update-service-account-token.xml
+              subPath: update-service-account-token.xml
+{{ end }}
+{{ if .Values.initContainers }}
+           {{- range .Values.initContainers }}
+           {{- range .volumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{ if .subPath }}
+              subPath: {{ .subPath }}
+              {{ end }}
+           {{- end }}
+           {{- end }}
+{{ end }}
+{{ if .Values.sidecars }}
+           {{- range .Values.sidecars }}
+           {{- range .volumeMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{ if .subPath }}
+              subPath: {{ .subPath }}
+              {{ end }}
+           {{- end }}
+           {{- end }}
+{{ end }}
           envFrom:
             - configMapRef:
                 name: {{ template "gateway.fullname" . }}-configmap
@@ -215,17 +253,55 @@ spec:
         - name: {{ template "gateway.fullname" . }}-restman
           emptyDir: {}
 {{ end }}
+{{ if .Values.management.kubernetes.loadServiceAccountToken }}
+        - name: {{ template "gateway.fullname" . }}-service-account-token-script
+          configMap:
+            name: {{ template "gateway.fullname" . }}-configmap
+            items:
+            - key: 002-load-service-account-token
+              path: 002-load-service-account-token.sh
+        - name: {{ template "gateway.fullname" . }}-service-account-token-template
+          configMap:
+            name: {{ template "gateway.fullname" . }}-configmap
+            items:
+            - key: update-service-account-token
+              path: update-service-account-token.xml
+{{ end }}
 {{ if .Values.existingBundle.enabled }}
      {{- range .Values.existingBundle.configMaps }}
-        - name: {{ . }}
+        - name: {{ .name }}
+      {{ if .configMap }}
+          configMap: {{ toYaml .configMap | nindent 12 }}
+      {{ else }}
           configMap:
             defaultMode: 292
             optional: false
-            name: {{ . }}
+            name: {{ .name }}
+      {{ end }}
      {{- end }}
      {{- range .Values.existingBundle.secrets }}
-        - name: {{ . }}
+        - name: {{ .name }}
+      {{ if .csi }}
+          csi: {{ toYaml .csi | nindent 12 }}
+      {{ else }}
           secret:
-            secretName: {{ . }}
+            secretName: {{ .name }}
+      {{ end }}
+     {{- end }}
+{{ end }}
+{{ if .Values.initContainers }}
+     {{- range .Values.initContainers }}
+     {{- range .volumeMounts }}
+        - name: {{ .name }}
+          emptyDir: {}
+     {{- end }}
+     {{- end }}
+{{ end }}
+{{ if .Values.sidecars }}
+     {{- range .Values.sidecars }}
+     {{- range .volumeMounts }}
+        - name: {{ .name }}
+          emptyDir: {}
+     {{- end }}
      {{- end }}
 {{ end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -23,6 +23,30 @@ imagePullSecret:
   username:
   password:
 
+# Add initContainers to the Gateway
+initContainers: {}
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+
+## Add sidecars to the Gateway Deployment.
+sidecars: {}
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+
 serviceAccount:
   # name:
   create: true
@@ -62,9 +86,12 @@ management:
   # Enable Restman, if DBbacked this setting will persist until manually deleted via Policy Manager.
   restman:
     enabled: false
-  # This is the username/password used for Policy Manager/Gateway Management
+  # This is the username/password used for Policy Manager/Gateway Management.
   username: admin
   password: mypassword
+  # This optionally loads the Kubernetes Service Account token as a secure password for use in Policy.
+  kubernetes:
+    loadServiceAccountToken: false
 
 # Database configuration
 database:
@@ -160,14 +187,12 @@ installSolutionKits:
   solutionKits:
 
 # Additional Environment variables to be added to the Gateway Configmap
-additionalEnv:
-  key1: value
+additionalEnv: {}
 # key1: value
 # key2: value
 
 # Additional Secret variables to be added to the Gateway Secret
-additionalSecret:
-  key1: value
+additionalSecret: {}
 # key1: value
 # key2: value
 
@@ -183,26 +208,37 @@ bundle:
 # When creating these secrets/configmaps the format should be
 # key: bundle1.bundle value: <xml value>
 # Each bundle that you create as a ConfigMap can not exceed 1MB in size.
+
+# Bundles that contain sensitive information can be mounted using the Kubernetes CSI Driver
 existingBundle:
   enabled: false
-  configMaps:
-  - mybundle1
-  - mybundle2
-  secrets:
-  - mysecretbundle1
-  - mysecretbundle2
+  configMaps: []
+ # - name: mybundle1
+    # configMap:
+    #   defaultMode: 420
+    #   optional: false
+    #   name: mybundle1
+ # - name: mybundle2
+  secrets: []
+  # - name: mysecretbundle1
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "secret-provider-class-name"
+ # - mysecretbundle2
 
 # Configure custom hosts
 customHosts:
   enabled: false
-  hostAliases:
-  - hostnames:
-    - "dev.ca.com"
-    - "dev1.ca.com"
-    ip: "0.0.0.0"
-  - hostnames:
-    - "example.ca.com"
-    ip: "0.0.0.0"
+  hostAliases: []
+  # - hostnames:
+  #   - "dev.ca.com"
+  #   - "dev1.ca.com"
+  #   ip: "0.0.0.0"
+  # - hostnames:
+  #   - "example.ca.com"
+  #   ip: "0.0.0.0"
 
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
@@ -260,14 +296,14 @@ ingress:
   secretName: tls-secret
   # Array of Hostnames that the certificate is valid for - must contain at least one.
   hostname: dev.ca.com
-  tlsHostnames:
-  - dev.ca.com
-  - dev1.ca.com
+  tlsHostnames: []
+  # - dev.ca.com
+  # - dev1.ca.com
   ## The port that you want to route to via ingress. This needs to be available via service.ports.
   port: 8443
   ## Define additional hostnames and ports as key-value pairs.
-  additionalHostnamesAndPorts:
-    dev1.ca.com: 9443
+  additionalHostnamesAndPorts: {}
+  #  dev1.ca.com: 9443
 
 livenessProbe:
   enabled: true


### PR DESCRIPTION
**Description of the change**
## 2.0.4 Updates to Secret Management
- Added support for the Kubernetes CSI Driver for gateway bundles. This does not currently extend to environment variables or the Gateway license.
- The CSI functionality is optional

## 2.0.4 General Updates
- Added support for sidecars and initContainers
  - volumeMounts are automatically configured with emptyDir 
- Updated default values update to reflect empty objects/arrays for optional fields.
- Load the Gateway Deployment's ServiceAccountToken as a stored password for querying the Kubernetes API.
  - management.kubernetes.loadServiceAccountToken

**Benefits**
Kubernetes integration, extends Gateway use cases.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

