### PR TITLE
Added custom host aliases to gateway-otk charts

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 1.0.2
+version: 1.0.3
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 dependencies:

--- a/charts/gateway-otk/README.md
+++ b/charts/gateway-otk/README.md
@@ -13,6 +13,9 @@ API Gateway is now running with Java 11 with the release of the v10.1.00. The Ga
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well. 
 
+## 1.0.3 Update
+- HostAliases applies to /etc/hosts for dns names that aren't available on a dns server.
+
 # Install the Chart
 
 ## From this Repository
@@ -89,6 +92,8 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `additionalSecret`          | Additional secret variables you wish to pass to the Gateway Secret | `see values.yaml`  |
 | `bundle.enabled`          | Create and mount an empty configMap that you can use to load policy bundles onto your Gateway | `false`  |
 | `bundle.path`          | Specify the path to the bundle files. The bundles folder in this repo has some example bundle files | `"bundles/*.bundle"`  |
+| `customHosts.enabled`    | Enable customHosts on the Gateway, this overrides /etc/hosts. | `see values.yaml` |
+| `customHosts.hostAliases`    | Array of hostAliases to add to the Container Gateway | `see values.yaml` |
 | `service.type`    | Service Type               | `LoadBalancer` |
 | `service.loadbal..`    | Additional Loadbalancer Configuration               | `see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service` |
 | `service.ports`    | List of http external port mappings               | https: 8443 -> 8443, management: 9443->9443 |

--- a/charts/gateway-otk/templates/deployment.yaml
+++ b/charts/gateway-otk/templates/deployment.yaml
@@ -113,6 +113,10 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
+{{ if .Values.customHosts.enabled }}
+      hostAliases:
+{{ toYaml .Values.customHosts.hostAliases | indent 12 }}
+{{ end }}
 {{ end }}
       volumes:
 {{ if  .Values.tls.customKey.enabled }}

--- a/charts/gateway-otk/values.yaml
+++ b/charts/gateway-otk/values.yaml
@@ -126,6 +126,18 @@ bundle:
   enabled: false
   path: "bundles/*.bundle"
 
+# Configure custom hosts
+customHosts:
+  enabled: false
+  hostAliases:
+  - hostnames:
+    - "dev.ca.com"
+    - "dev1.ca.com"
+    ip: "0.0.0.0"
+  - hostnames:
+    - "example.ca.com"
+    ip: "0.0.0.0"
+
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
   type: LoadBalancer


### PR DESCRIPTION
**Description of the change**

Added custom host aliases to gateway-otk charts

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

