### PR TITLE
[charts/gateway-otk] update network api to v1 for kube v1.19+

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 1.0.2
+version: 1.0.3
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 dependencies:

--- a/charts/gateway-otk/templates/ingress.yaml
+++ b/charts/gateway-otk/templates/ingress.yaml
@@ -1,51 +1,64 @@
 {{ if .Values.ingress.enabled }}
-# apiVersion: networking.k8s.io/v1beta1
-apiVersion: extensions/v1beta1
+{{- $kubeTargetVersion := .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  labels:
-    chart: {{ template "gateway.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  name: {{ template "gateway.fullname" . }}
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+ name: {{ template "gateway.fullname" . }}-ingress
+ labels:
+   chart: {{ template "gateway.chart" . }}
+   release: {{ .Release.Name }}
+   heritage: {{ .Release.Service }}
+ annotations:
 {{- range $key, $val := .Values.ingress.annotations }}
-    {{ $key }}: "{{ $val }}"
+   {{ $key }}: "{{ $val }}"
 {{- end }}
 spec:
-{{ if .Values.ingress.tls }}
   tls:
-  {{ if .Values.ingress.secretName }}
-  - secretName: {{.Values.ingress.secretName}}
-  {{ end }}
-  - hosts:
-  {{if .Values.ingress.hostname }}
-    - {{ .Values.ingress.hostname }}
-  {{ else }}
-    - {{ .Values.clusterHostname }}
-  {{ end }}
-{{ end }}
+  - secretName: {{ .Values.ingress.secretName }}
+    hosts:
+    {{- range .Values.ingress.tlsHostnames}}
+    - {{ . }}
+    {{- end }}
   rules:
-  {{if .Values.ingress.hostname }}
   - host: {{ .Values.ingress.hostname }}
-  {{ else }}
-  - host: {{ .Values.clusterHostname }}
-  {{ end }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {{ template "gateway.fullname" . }}
+            port:
+              number: {{ .Values.ingress.port }}
+{{- else }}
       - backend:
           serviceName: {{ template "gateway.fullname" . }}
           servicePort: {{ .Values.ingress.port }}
+{{- end }}
   {{if .Values.ingress.additionalHostnamesAndPorts }}
   {{- $gatewayFullName := include "gateway.fullname" . }}
   {{- range $key, $val := .Values.ingress.additionalHostnamesAndPorts }}
   - host: {{ $key }}
     http:
       paths:
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {{ $gatewayFullName }}
+            port:
+              number: {{ $val }}
+{{- else }}
       - backend:
           serviceName: {{ $gatewayFullName }}
           servicePort: {{ $val }}
+{{- end }}
   {{- end }}
   {{ end }}
-{{ end }}
+  {{ end }}

--- a/charts/gateway-otk/values.yaml
+++ b/charts/gateway-otk/values.yaml
@@ -168,22 +168,28 @@ service:
 ingress:
   # Set to true to create ingress object
   enabled: false
-  class: nginx
   # Ingress annotations
   annotations:
   # Ingress class
-  #  nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+  # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   # When the ingress is enabled, a host pointing to this will be created
   # By default clusterHostname is used, only set this if you want to use a different host
-  hostname:
-  ## The port that you want to route to via ingress. This needs to be available via service.ports.
-  port: https
-  ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
-  tls: false
-  secretName:
+   ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
 
-  #Need to configure additional ingress options for hosts/tls
+  # TLS Secret Name - this must present in your Kubernetes Cluster.
+  secretName: tls-secret
+  # Array of Hostnames that the certificate is valid for - must contain at least one.
+  hostname: dev.ca.com
+  tlsHostnames: []
+  # - dev.ca.com
+  # - dev1.ca.com
+  ## The port that you want to route to via ingress. This needs to be available via service.ports.
+  port: 8443
+  ## Define additional hostnames and ports as key-value pairs.
+  additionalHostnamesAndPorts: {}
+  #  dev1.ca.com: 9443
 
 livenessProbe:
   enabled: true


### PR DESCRIPTION
**Description of the change**
update otk chart for v1 ingress api

**Benefits**
required for kube v1.22+ where the beta version is deprecated

**Drawbacks**
none

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

