### PR TITLE
[charts/gateway] v2.0.5

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 2.0.4
+version: 2.0.5
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -13,6 +13,37 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
 - MySQL Stable Chart is deprecated - the demo database subChart has been changed to Bitnami MySQL - if your database is NOT externalised you will lose any policy/configuration you have there.
 - tls.customKey ==> tls.useSignedCertificates tls.key tls.pass tls.existingSecretName
 
+## 2.0.5 Updates to Gateway Service
+- Updated naming conventions to reflect standards. You will need to update your values file to reflect this. If you wish to continue to use the old format specify --version 2.0.4 on install/upgrade
+
+```
+v2.0.4
+------
+ports:
+  - name: https
+    internal: 8443
+    external: 8443
+  - name: management
+    internal: 9443
+    external: 9443
+
+v2.0.5 onwards
+------
+ports:
+  - name: https
+    port: 8443
+    targetPort: 8443
+    protocol: TCP
+  - name: management
+    port: 9443
+    targetPort: 9443
+    protocol: TCP
+```
+
+
+- Added name to containerPorts for more consistent service resolution
+- Added ingressClassName options for Gateway Ingress
+
 ## 2.0.4 Updates to Secret Management
 - Added support for the Kubernetes CSI Driver for gateway bundles. This does not currently extend to environment variables or the Gateway license.
 - The CSI functionality is optional
@@ -144,12 +175,14 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `service.ports`    | List of http external port mappings               | https: 8443 -> 8443, management: 9443->9443 |
 | `service.annotations`    | Additional annotations to add to the service               | {} |
 | `ingress.enabled`    | Enable/Disable an ingress record being created               | `false` |
+| `ingress.class.enabled`    | Use spec.IngressClassName vs. old annotation kubernetes.io/ingress.class               | `false` |
+| `ingress.class.name`    | Specify Ingress Class Name               | `nginx` |
 | `ingress.annotations`    | Additional ingress annotations               | `{}` |
 | `ingress.hostname`    | Sets Ingress Hostname  | `nil` |
 | `ingress.port`    | The Gateway Port number/name to route to  | `8443` |
-| `ingress.tlsHostnames`    | Register additional Hostnames for the TLS Certificate  | `see values.yaml` |
+| `ingress.tlsHostnames`    | Register additional Hostnames for the TLS Certificate  | `[]` |
 | `ingress.secretName`    | The name of an existing Cert secret, setting this does not auto-create the secret               | `tls-secret` |
-| `ingress.additionalHostnamesAndPorts`    | key/value pairs of hostname:port that will be added to the ingress object  | `see values.yaml` |
+| `ingress.additionalHostnamesAndPorts`    | key/value pairs of hostname:port that will be added to the ingress object  | `{}` |
 | `livenessProbe.enabled`    | Enable/Disable               | `true` |
 | `livenessProbe.initialDelaySeconds`    | Initial delay               | `60` |
 | `livenessProbe.timeoutSeconds`    | Timeout               | `1` |

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -70,7 +70,8 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
             {{- range .Values.service.ports }}
-            - containerPort: {{ .internal }}
+            - containerPort: {{ .targetPort }}
+              name: {{ .name }}
             {{- end }}
           volumeMounts:
             - name: {{ template "gateway.fullname" . }}-license-xml

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
    {{ $key }}: "{{ $val }}"
 {{- end }}
 spec:
+ {{- if and (semverCompare ">=1.19-0" $kubeTargetVersion) (.Values.ingress.class.enabled) }}
+  ingressClassName: {{ .Values.ingress.class.name }}
+ {{- end }} 
   tls:
   - secretName: {{ .Values.ingress.secretName }}
     hosts:

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: {{ template "gateway.name" . }}
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -29,9 +30,9 @@ spec:
   {{- end }}
   ports:
   {{- range .Values.service.ports }}
-    - protocol: TCP
-      port: {{ .external }}
-      targetPort: {{ .internal }}
+    - protocol: {{ .protocol }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
       name: {{ .name | quote }}
   {{- end }}
   {{- if .Values.service.sessionAffinity }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -257,14 +257,22 @@ service:
   ##
   # loadBalancerIP:
 
-  # Update this port list if additional ports need to be exposed
+  # # Update this port list if additional ports need to be exposed
   ports:
     - name: https
-      internal: 8443
-      external: 8443
+      port: 8443
+      targetPort: 8443
+      protocol: TCP
     - name: management
-      internal: 9443
-      external: 9443
+      port: 9443
+      targetPort: 9443
+      protocol: TCP
+    # - name: metrics
+    #   port: 8080
+    #   targetPort: 8080
+    #   protocol: TCP
+
+
   # Additional Service annotations, the example below shows configuration for an internal load balancer on GCP
   # See the docs for more ==> https://kubernetes.io/docs/concepts/services-networking/service/
   annotations: {}
@@ -283,9 +291,12 @@ ingress:
   # Set to true to create ingress object
   enabled: false
   # Ingress annotations
+  class:
+    name: nginx
+    enabled: false
   annotations:
   # Ingress class
-    kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   # When the ingress is enabled, a host pointing to this will be created


### PR DESCRIPTION
**Description of the change**
## 2.0.5 Updates to Gateway Service
- Updated naming conventions to reflect standards. You will need to update your values file to reflect this. If you wish to continue to use the old format specify --version 2.0.4 on install/upgrade

```
v2.0.4
------
ports:
  - name: https
    internal: 8443
    external: 8443
  - name: management
    internal: 9443
    external: 9443

v2.0.5 onwards
------
ports:
  - name: https
    port: 8443
    targetPort: 8443
    protocol: TCP
  - name: management
    port: 9443
    targetPort: 9443
    protocol: TCP
```


- Added name to containerPorts for more consistent service resolution
- Added ingressClassName options for Gateway Ingress

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

