### PR TITLE
Removed the word "hazelcast" from hazelcast-client address as if rele…

### DIFF
--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
                 {{ if .Values.hazelcast.external }}
                 <address>{{ required "Please set an external Hazelcast URL in values.yaml" .Values.hazelcast.url }}</address>
                 {{ else }}
-                 <address>{{ .Release.Name }}-hazelcast.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.hazelcast.service.port }}</address>
+                 <address>{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.hazelcast.service.port }}</address>
                 {{ end }}
             </cluster-members>
             <connection-attempt-limit>10</connection-attempt-limit>


### PR DESCRIPTION
Removed the word "hazelcast" from hazelcast-client address as if release-name had "hazelcast", hazelcast-client is unable to connect with gateway

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

