### PR TITLE
updating the bitnami repo to work around the issue with bitnami 

### DIFF
--- a/charts/portal/Chart.lock
+++ b/charts/portal/Chart.lock
@@ -3,10 +3,10 @@ dependencies:
   repository: file://../druid
   version: 1.0.8
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 8.8.16
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
   version: 7.6.6
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx/

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -17,11 +17,11 @@ dependencies:
   repository: "file://../druid"
 - name: mysql
   version: 8.8.16
-  repository: "https://charts.bitnami.com/bitnami"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: global.setupDemoDatabase
 - name: rabbitmq
   version: 7.6.6
-  repository: "https://charts.bitnami.com/bitnami"
+  repository: "https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami"
   condition: rabbitmq.enabled
 - name: ingress-nginx
   repository: "https://kubernetes.github.io/ingress-nginx/"


### PR DESCRIPTION
Due to the issue with bitnami charts reported here https://github.com/bitnami/charts/issues/10539 we need to work around the issue by providing a different url for the bitnami chart repo

**Benefits**

build will pass :)

**Drawbacks**

None

**Applicable issues**

None

  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

