### PR TITLE
updating the digest value for chart.lock changes

### DIFF
--- a/charts/portal/Chart.lock
+++ b/charts/portal/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx/
   version: 4.0.9
-digest: sha256:6b0621c97c5a0c365802a5cf33a4b95377d2aef7ab0868d6dc69adf0e46ee5ba
-generated: "2022-02-10T21:48:48.558598+05:30"
+digest: sha256:2fe61485ca51763c36ea978445378b12692baa33a630f701f1c52566144afd6a
+generated: "2022-06-22T13:00:43.4999218+05:30"


### PR DESCRIPTION
since the chart.lock has been changed for updating the bitnami repo - updated digest also

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

