### PR TITLE
charts/gateway pm-tagger conditional fix

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.0
+version: 3.0.1
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -720,7 +720,7 @@ The following table lists the configured parameters of the Hazelcast Subchart - 
 | -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
 | `hazelcast.enabled`                | Enable/Disable deployment of Hazelcast   | `false` |
 | `hazelcast.external`                | Point to an external Hazelcast - set enabled to false and configure the url  | `false` |
-| `hazelcast.image.tag`                | The Gateway currently supports Hazelcast 3.x servers.  | `5.1.1` |
+| `hazelcast.image.tag`                | The Gateway currently supports Hazelcast 4.x/5.x servers.  | `5.1.1` |
 | `hazelcast.url`                | External Hazelcast Url  | `hazelcast.example.com:5701` |
 | `hazelcast.cluster.memberCount`                | Number of Hazelcast Replicas you wish to deploy   | `see values.yaml` |
 | `hazelcast.hazelcast.yaml`                | Hazelcast configuration   | `see the documentation link` |

--- a/charts/gateway/templates/pm-tagger-deployment.yaml
+++ b/charts/gateway/templates/pm-tagger-deployment.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.pmtagger.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,3 +55,4 @@ spec:
             items:
             - key: config.yaml
               path: config.yaml
+{{ end }}

--- a/charts/gateway/templates/pm-tagger-role.yaml
+++ b/charts/gateway/templates/pm-tagger-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+{{- if and .Values.serviceAccount.create .Values.rbac.create .Values.pmtagger.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/gateway/templates/pm-tagger-rolebinding.yaml
+++ b/charts/gateway/templates/pm-tagger-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.rbac.create }}
+{{- if and .Values.serviceAccount.create .Values.rbac.create .Values.pmtagger.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
**Description of the change**
Fix to make the pm-tagger deployment optional.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

