### PR TITLE
Parametrize enabling restman in portal ingress

### DIFF
--- a/charts/portal/templates/apim/apim-deployment.yaml
+++ b/charts/portal/templates/apim/apim-deployment.yaml
@@ -197,11 +197,15 @@ spec:
             - containerPort: 9449
             - containerPort: 1885
             - containerPort: 9448
-          {{ if contains "4.5" .Chart.AppVersion }}
           volumeMounts:
+          {{ if contains "4.5" .Chart.AppVersion }}
             - name: {{.Values.portal.license.secretName}}
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/license/license.xml
               subPath: license.xml
+          {{ end }}
+          {{ if .Values.apim.restman.enabled }}
+            - name: apim-restman
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/services/restman
           {{ end }}
       {{- if .Values.global.pullSecret }}
       imagePullSecrets:
@@ -209,12 +213,16 @@ spec:
       {{- end }}
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
-      {{ if contains "4.5" .Chart.AppVersion }}
       volumes:
+      {{ if contains "4.5" .Chart.AppVersion }}
         - name: {{.Values.portal.license.secretName}}
           secret:
             secretName: {{.Values.portal.license.secretName}}
             items:
               - key: license
                 path: license.xml
+      {{ end }}
+      {{ if .Values.apim.restman.enabled }}
+        - name: apim-restman
+          emptyDir: {}
       {{ end }}

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -210,6 +210,8 @@ apim:
 # tolerations: []
 # affinity: {}
   additionalEnv:
+  restman:
+    enable: false
 
 authenticator:
   forceRedeploy: false


### PR DESCRIPTION
Please note that this is for internal use only, basically to be able to run RAT tests on Portal.

However, it will expose the functionality to portal customers if merge the PR to develop/portal, then stable.

Thus will need portal PMs/POs/Dev to decide on whether or not to include the function to the portal helm chart.