### PR TITLE
[charts/gateway-otk] Otk tolerations

### DIFF
--- a/charts/gateway-otk/templates/deployment.yaml
+++ b/charts/gateway-otk/templates/deployment.yaml
@@ -20,7 +20,13 @@ spec:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{ include "gateway.serviceAccountName" . }}      
+      serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- toYaml .Values.tolerations | nindent 12 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 12 }}
+      {{- end }}
 {{ if .Values.image.secretName }}
       imagePullSecrets:
         - name: {{ .Values.image.secretName | quote }}

--- a/charts/gateway-otk/values.yaml
+++ b/charts/gateway-otk/values.yaml
@@ -236,6 +236,9 @@ serviceAccount:
   # name:
   create: true
 
+# nodeSelector: {}
+tolerations: []
+
 ###############################################################################################
 ##                                                                                           ##
 ##                              Subchart Configuration                                       ##
@@ -263,6 +266,7 @@ mysql:
       max_allowed_packet = 20M
       default-authentication-plugin=mysql_native_password
       log-bin-trust-function-creators=1
+
 
 
 # Settings for Hazelcast - https://github.com/hazelcast/charts/blob/master/stable/hazelcast/values.yaml


### PR DESCRIPTION
**Description of the change**
add nodeSelector and tolerations to otk chart

**Benefits**
enable select target pool to deploy to based on taint config

**Drawbacks**
none

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

