### PR TITLE
[charts/gateway] Moved affinity/tolerations/nodeselecter to Values.pmtagger

### DIFF
--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -66,6 +66,11 @@ pmtagger:
     limits:
       memory: 64Mi
       cpu: 250m
+  # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  # nodeSelector: {}
+  # affinity: {}
+  # ref:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
 # Cluster Hostname
 clusterHostname: my.localdomain

--- a/charts/gateway/templates/pm-tagger-deployment.yaml
+++ b/charts/gateway/templates/pm-tagger-deployment.yaml
@@ -24,13 +24,13 @@ spec:
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.affinity }}
-      affinity: {{- toYaml .Values.affinity | nindent 12 }}
+      affinity: {{- toYaml .Values.pmtagger.affinity | nindent 12 }}
       {{- end }}
       {{- if .Values.tolerations }}
-      tolerations: {{- toYaml .Values.tolerations | nindent 12 }}
+      tolerations: {{- toYaml .Values.pmtagger.tolerations | nindent 12 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.nodeSelector | nindent 12 }}
+      nodeSelector: {{- toYaml .Values.pmtagger.nodeSelector | nindent 12 }}
       {{- end }}
       {{- if .Values.global.schedulerName }}
       schedulerName: {{ .Values.global.schedulerName }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -66,6 +66,11 @@ pmtagger:
     limits:
       memory: 64Mi
       cpu: 250m
+  # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  # nodeSelector: {}
+  # affinity: {}
+  # ref:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
 
 # Cluster Hostname
 clusterHostname: my.localdomain


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

Added the changes as listed by @Gazza7205 in https://github.com/CAAPIM/apim-charts/pull/181
