### PR TITLE
[charts/gateway]: Update 10.1.00_CR2 tag to 11.0.00

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "10.1.00_CR2"
+appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.4
+version: 3.0.5
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,11 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.5 General Updates
+The default image tag in values.yaml and production-values.yaml, and the appVersion in Chart.yaml have been updated to **11.0.00**.
+
+Before upgrading existing deployments, please see the [Container Gateway 11.0 Release Notes](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/congw-11-0/release-notes_cgw.html) for important information regarding the procedure.
+
 ## 3.0.4 General Updates
 OTK installation and upgrade is now supported as part of Gateway charts.  Please refer to [OTK Install or Upgrade](#otk-install-or-upgrade) for more details.
 [Gateway-OTK](../gateway-otk) is now deprecated.

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,9 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.4 General Updates
+OTK intallation and upgrade is now supported as part of Gateway charts.  Reffer to [OTK Install or Upgrade](#otk-install-or-upgrade) for more details.
+
 ## 3.0.2 General Updates
 ***The default image tag in values.yaml and production-values.yaml now points at specific GA or CR versions of the API Gateway. The appVersion in Chart.yaml has also be updated to reflect that. As of this release that is 11.0.00***
 
@@ -328,7 +331,7 @@ management:
         protocol: TCP
 ```
 ### OTK install or upgrade
-OTK job is used to install or upgrade otk on gateway. It supports single, internal and external type of OTK installations.
+OTK job is used to install or upgrade otk on gateway. It supports Single, Internal and DMZ type of OTK installations.
 
 Prerequisites:
 * Create or upgrade the OTK Database https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-management-oauth-toolkit/4-6/installation-workflow/create-or-upgrade-the-otk-database.html

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -47,7 +47,7 @@ OTK installation and upgrade is now supported as part of Gateway charts.  Please
 [Gateway-OTK](../gateway-otk) is now deprecated.
 
 ## 3.0.2 General Updates
-***The default image tag in values.yaml and production-values.yaml now points at specific GA or CR versions of the API Gateway. The appVersion in Chart.yaml has also be updated to reflect that. As of this release that is 11.0.00***
+***The default image tag in values.yaml and production-values.yaml now points at specific GA or CR versions of the API Gateway. The appVersion in Chart.yaml has also been updated to reflect that. As of this release, that is 10.1.00_CR2***
 
 To reduce reliance on requiring a custom/derived gateway image for custom and modular assertions, scripts and restman bundles a bootstrap script has been introduced. The script works with the /opt/docker/custom folder.
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -38,7 +38,8 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
 ## 3.0.4 General Updates
-OTK intallation and upgrade is now supported as part of Gateway charts.  Reffer to [OTK Install or Upgrade](#otk-install-or-upgrade) for more details.
+OTK installation and upgrade is now supported as part of Gateway charts.  Please refer to [OTK Install or Upgrade](#otk-install-or-upgrade) for more details.
+[Gateway-OTK](../gateway-otk) is now deprecated.
 
 ## 3.0.2 General Updates
 ***The default image tag in values.yaml and production-values.yaml now points at specific GA or CR versions of the API Gateway. The appVersion in Chart.yaml has also be updated to reflect that. As of this release that is 11.0.00***

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -172,7 +172,7 @@ database:
 * [Gateway Application Ports](#gateway-application-ports)
 * [Ingress Configuration](#ingress-configuration)
 * [PM Tagger Configuration](#pm-tagger-configuration)
-* [OTK Install or Upgrage](#otk-install-or-upgrage)
+* [OTK Install or Upgrade](#otk-install-or-upgrade)
 * [Database Configuration](#database-configuration)
 * [Cluster-Wide Properties](#cluster-wide-properties)
 * [Java Args](#java-args)
@@ -327,7 +327,7 @@ management:
         external: 9443
         protocol: TCP
 ```
-### OTK install or upgrage
+### OTK install or upgrade
 OTK job is used to install or upgrade otk on gateway. It supports single, internal and external type of OTK installations.
 
 Prerequisites:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -38,7 +38,7 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
 ## 3.0.2 General Updates
-***The default image tag in values.yaml and production-values.yaml now points at specific CR versions of the API Gateway. The appVersion in Chart.yaml has also be updated to reflect that. As of this release that is 10.1.00_CR2***
+***The default image tag in values.yaml and production-values.yaml now points at specific GA or CR versions of the API Gateway. The appVersion in Chart.yaml has also be updated to reflect that. As of this release that is 11.0.00***
 
 To reduce reliance on requiring a custom/derived gateway image for custom and modular assertions, scripts and restman bundles a bootstrap script has been introduced. The script works with the /opt/docker/custom folder.
 
@@ -199,7 +199,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `license.accept`          | Accept Gateway license EULA | `false`  |
 | `image.registry`    | Image Registry               | `docker.io` |
 | `image.repository`          | Image Repository  | `caapim/gateway`  |
-| `image.tag`          | Image tag | `10.1.00_CR2`  |
+| `image.tag`          | Image tag | `11.0.00`  |
 | `image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `imagePullSecret.enabled`          | Configures Gateway Deployment to use imagePullSecret, you can also leave this disabled and associate an image pull secret with the Gateway's Service Account | `false`  |
 | `imagePullSecret.existingSecretName`          | Point to an existing Image Pull Secret | `commented out`  |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -12,7 +12,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 10.1.00_CR2
+  tag: 11.0.00
   pullPolicy: IfNotPresent
 
 # If you are using a Hazelcast 3.x server then you need to set hazelcast.legacy.enabled=true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -12,7 +12,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 10.1.00_CR2
+  tag: 11.0.00
   pullPolicy: IfNotPresent
 
 # If you are using a Hazelcast 3.x server then you need to set hazelcast.legacy.enabled=true
@@ -370,8 +370,8 @@ management:
     type: LoadBalancer
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-    annotations: {}
-      # cloud.google.com/load-balancer-type: "Internal"
+    annotations:
+      cloud.google.com/load-balancer-type: "Internal"
     ports:
       # - name: https
       #   internal: 8443
@@ -411,8 +411,8 @@ service:
     #   protocol: TCP
   # Additional Service annotations, the example below shows configuration for an internal load balancer on GCP
   # See the docs for more ==> https://kubernetes.io/docs/concepts/services-networking/service/
-  annotations: {}
-    # cloud.google.com/load-balancer-type: "Internal"
+  annotations:
+    cloud.google.com/load-balancer-type: "Internal"
     # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 
   # Uncomment the following section to enable session affinity

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -370,8 +370,8 @@ management:
     type: LoadBalancer
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-    annotations:
-      cloud.google.com/load-balancer-type: "Internal"
+    annotations: {}
+      # cloud.google.com/load-balancer-type: "Internal"
     ports:
       # - name: https
       #   internal: 8443
@@ -411,8 +411,8 @@ service:
     #   protocol: TCP
   # Additional Service annotations, the example below shows configuration for an internal load balancer on GCP
   # See the docs for more ==> https://kubernetes.io/docs/concepts/services-networking/service/
-  annotations:
-    cloud.google.com/load-balancer-type: "Internal"
+  annotations: {}
+    # cloud.google.com/load-balancer-type: "Internal"
     # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 
   # Uncomment the following section to enable session affinity


### PR DESCRIPTION
**Description of the change**

Update Gateway image version from 10.1.00_CR2 to 11.0.00

**Benefits**

Enable usage of latest release of Layer 7 Gateway

**Drawbacks**

None. It's a straightforward version update. The image already exists on Docker Hub.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
Verified on GKE using local copy of fork:
```
PS C:\Users\jd683606.BRCMLTD\work\github\CAAPIM\apim-charts-jennarddy\charts> helm install jd683606-ssg-11 --set-file "license.value=LICENSE.xml" --set "license.accept=true" gateway
NAME: jd683606-ssg-11
LAST DEPLOYED: Mon Jan 30 18:04:36 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
##################################################################################
####                                 Success!                                 ####
##################################################################################
####                 Your gateway deployment has been INSTALLED               ####
##################################################################################

To view the Gateway's services you can use the following command
$ kubectl get svc -n default | grep gateway

To learn more about the Gateway Helm Chart check out the following links

Gateway Helm Chart Readme
- https://github.com/CAAPIM/apim-charts/tree/stable/charts/gateway

Thinking in Kubernetes
- https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/congw-10-1/learning-center/thinking-in-kubernetes.html#thinkingk8s

PS C:\Users\jd683606.BRCMLTD\work\github\CAAPIM\apim-charts-jennarddy\charts> kubectl get svc -n default
jd683606-ssg-11-gateway                   LoadBalancer   240.129.245.154   10.210.128.136   8443:32660/TCP                                  3m5s
jd683606-ssg-11-gateway-management        LoadBalancer   240.129.244.73    10.210.128.172   9443:31896/TCP                                  3m5s
jd683606-ssg-11-mysql                     ClusterIP      240.129.246.197   <none>           3306/TCP                                        3m5s
jd683606-ssg-11-mysql-headless            ClusterIP      None              <none>           3306/TCP                                        3m5s
```

Logged on to Policy Manager using 10.210.128.172:9443
![image](https://user-images.githubusercontent.com/25108787/215648125-431fbba7-df70-4c92-a0d0-0330b44c7430.png)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

