### PR TITLE
[charts/gateway] Update license info in Prerequisites section of README

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.5
+version: 3.0.6
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -8,7 +8,9 @@ The included MySQL subChart is enabled by default to make trying this chart out 
 - Kubernetes 1.24.x
   - [Refer to techdocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/congw-10-1/release-notes_cgw/container-gateway-platform-support.html#concept.dita_3277fc35fde9c5232f0d64d7a360181d5d18fd6c) for the latest version support
 - Helm v3.7.x
-- Gateway v10.x License
+- Gateway License
+  - License for corresponding major version needed
+  - e.g. v11.x license for 11.0.00 tag, v10.x license for 10.1.00_CR2 tag
 
 ## Optional
 - Persistent Volume Provisioner (if using PVC for the Demo MySQL Database or Service Metrics example with Grafana or InfluxDb)


### PR DESCRIPTION
**Description of the change**

Reference to Gateway version is removed in the license info. Provided GW 11 and 10 examples.

**Benefits**

We don't have to update the license info in future anymore since the Gateway version reference is removed.

**Drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

