### PR TITLE
OTK 4.6.1 release.

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.5
+version: 3.0.6
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -405,11 +405,11 @@ database:
 | `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `false`
 | `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false`
 | `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config`
-| `otk.livenessProbe.enabled`                | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1 | `false`
+| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1 | `false`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`
 | `otk.livenessProbe.httpGet.port`           |  | `8443`
-| `otk.readinessProbe.enabled`               | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1  | `false`
+| `otk.readinessProbe.enabled`               | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1  | `false`
 | `otk.readinessProbe.type`                  |  | `httpGet`
 | `otk.readinessProbe.httpGet.path`          |  | `/auth/oauth/health`
 | `otk.readinessProbe.httpGet.port`          |  | `8443`

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -402,14 +402,14 @@ database:
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
 | `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
-| `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `false`
+| `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `true`
 | `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false`
 | `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config`
-| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1 | `false`
+| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1 | `true`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`
 | `otk.livenessProbe.httpGet.port`           |  | `8443`
-| `otk.readinessProbe.enabled`               | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1  | `false`
+| `otk.readinessProbe.enabled`               | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1  | `true`
 | `otk.readinessProbe.type`                  |  | `httpGet`
 | `otk.readinessProbe.httpGet.path`          |  | `/auth/oauth/health`
 | `otk.readinessProbe.httpGet.port`          |  | `8443`

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -399,11 +399,11 @@ database:
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
 | `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
-| `otk.livenessProbe.enabled`                |  Enable/Disable Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete | `false`
+| `otk.livenessProbe.enabled`                | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1 | `false`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`
 | `otk.livenessProbe.httpGet.port`           |  | `8443`
-| `otk.readinessProbe.enabled`               | Enable/Disable Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete  | `false`
+| `otk.readinessProbe.enabled`               | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1  | `false`
 | `otk.readinessProbe.type`                  |  | `httpGet`
 | `otk.readinessProbe.httpGet.path`          |  | `/auth/oauth/health`
 | `otk.readinessProbe.httpGet.port`          |  | `8443`

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,9 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.6 General Updates
+The default image tag in values.yaml and production-values.yaml for OTK updated to **4.6.1**. Support for liveness and readiness probes using OTK health check service. 
+
 ## 3.0.5 General Updates
 The default image tag in values.yaml and production-values.yaml, and the appVersion in Chart.yaml have been updated to **11.0.00**.
 
@@ -399,6 +402,9 @@ database:
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
 | `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
+| `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `false`
+| `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false`
+| `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config`
 | `otk.livenessProbe.enabled`                | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1 | `false`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -342,6 +342,8 @@ management:
 ### OTK install or upgrade
 OTK job is used to install or upgrade otk on gateway. It supports Single, Internal and DMZ type of OTK installations.
 
+***NOTE: In dual gateway installation, restart the pods after OTK install or upgrade is required.***
+
 Prerequisites:
 * Create or upgrade the OTK Database https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-management-oauth-toolkit/4-6/installation-workflow/create-or-upgrade-the-otk-database.html
 * Configure cluster wide property for otk.port pointing to gateway ingress port.
@@ -405,11 +407,11 @@ database:
 | `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `true`
 | `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false`
 | `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config`
-| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1 | `true`
+| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1. Valid only for SINGLE and INTERNAL OTK type installation. | `true`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`
 | `otk.livenessProbe.httpGet.port`           |  | `8443`
-| `otk.readinessProbe.enabled`               | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1  | `true`
+| `otk.readinessProbe.enabled`               | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.1. Valid only for SINGLE and INTERNAL OTK type installation.  | `true`
 | `otk.readinessProbe.type`                  |  | `httpGet`
 | `otk.readinessProbe.httpGet.path`          |  | `/auth/oauth/health`
 | `otk.readinessProbe.httpGet.port`          |  | `8443`

--- a/charts/gateway/bundles/otk-healthcheck.bundle
+++ b/charts/gateway/bundles/otk-healthcheck.bundle
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+    <l7:References>
+        <l7:Item>
+            <l7:Name>OtkHealthCheck</l7:Name>
+            <l7:Id>2ace60fb68280f90e1919e6565c70e9c</l7:Id>
+            <l7:Type>SERVICE</l7:Type>
+            <l7:TimeStamp>2023-02-23T12:02:00.861Z</l7:TimeStamp>
+            <l7:Resource>
+                <l7:Service id="2ace60fb68280f90e1919e6565c70e9c">
+                    <l7:ServiceDetail folderId="0000000000000000ffffffffffffec76" id="2ace60fb68280f90e1919e6565c70e9c">
+                        <l7:Name>OtkHealthCheck</l7:Name>
+                        <l7:Enabled>true</l7:Enabled>
+                        <l7:ServiceMappings>
+                            <l7:HttpMapping>
+                                <l7:UrlPattern>/otk/health</l7:UrlPattern>
+                                <l7:Verbs>
+                                    <l7:Verb>GET</l7:Verb>
+                                </l7:Verbs>
+                            </l7:HttpMapping>
+                        </l7:ServiceMappings>
+                        <l7:Properties>
+                            <l7:Property key="hasRouting">
+                                <l7:BooleanValue>true</l7:BooleanValue>
+                            </l7:Property>
+                            <l7:Property key="internal">
+                                <l7:BooleanValue>false</l7:BooleanValue>
+                            </l7:Property>
+                            <l7:Property key="policyRevision">
+                            <l7:Property key="soap">
+                                <l7:BooleanValue>false</l7:BooleanValue>
+                            </l7:Property>
+                            <l7:Property key="tracingEnabled">
+                                <l7:BooleanValue>false</l7:BooleanValue>
+                            </l7:Property>
+                            <l7:Property key="wssProcessingEnabled">
+                                <l7:BooleanValue>false</l7:BooleanValue>
+                            </l7:Property>
+                        </l7:Properties>
+                    </l7:ServiceDetail>
+                    <l7:Resources>
+                        <l7:ResourceSet tag="policy">
+                            <l7:Resource type="policy">&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;wsp:Policy xmlns:L7p=&quot;http://www.layer7tech.com/ws/policy&quot; xmlns:wsp=&quot;http://schemas.xmlsoap.org/ws/2002/12/policy&quot;&gt;
+    &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
+        &lt;L7p:SslAssertion/&gt;
+        &lt;L7p:RemoteIpAddressRange&gt;
+            &lt;L7p:NetworkMask stringValue=&quot;16&quot;/&gt;
+            &lt;L7p:StartIp stringValue=&quot;240.224.2.1&quot;/&gt;
+        &lt;/L7p:RemoteIpAddressRange&gt;
+        &lt;L7p:SetVariable&gt;
+            &lt;L7p:Base64Expression stringValue=&quot;YWR2YW5jZWQ=&quot;/&gt;
+            &lt;L7p:VariableToSet stringValue=&quot;check_type&quot;/&gt;
+        &lt;/L7p:SetVariable&gt;
+        &lt;L7p:SetVariable&gt;
+            &lt;L7p:Base64Expression stringValue=&quot;JHtyZXF1ZXN0Lmh0dHAucGFyYW1ldGVyLmNsaWVudF9pZH0=&quot;/&gt;
+            &lt;L7p:VariableToSet stringValue=&quot;client_id&quot;/&gt;
+        &lt;/L7p:SetVariable&gt;
+        &lt;L7p:SetVariable&gt;
+            &lt;L7p:Base64Expression stringValue=&quot;JHtyZXF1ZXN0Lmh0dHAucGFyYW1ldGVyLmFwaWtleX0=&quot;/&gt;
+            &lt;L7p:VariableToSet stringValue=&quot;api_key&quot;/&gt;
+        &lt;/L7p:SetVariable&gt;
+        &lt;wsp:OneOrMore wsp:Usage=&quot;Required&quot;&gt;
+            &lt;L7p:ComparisonAssertion&gt;
+                &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                &lt;L7p:Expression1 stringValue=&quot;${request.http.parameter.check_type}&quot;/&gt;
+                &lt;L7p:ExpressionIsVariable booleanValue=&quot;false&quot;/&gt;
+                &lt;L7p:Operator operatorNull=&quot;null&quot;/&gt;
+                &lt;L7p:Predicates predicates=&quot;included&quot;&gt;
+                    &lt;L7p:item dataType=&quot;included&quot;&gt;
+                        &lt;L7p:Type variableDataType=&quot;string&quot;/&gt;
+                    &lt;/L7p:item&gt;
+                    &lt;L7p:item binary=&quot;included&quot;&gt;
+                        &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                        &lt;L7p:RightValue stringValue=&quot;advanced&quot;/&gt;
+                    &lt;/L7p:item&gt;
+                &lt;/L7p:Predicates&gt;
+            &lt;/L7p:ComparisonAssertion&gt;
+            &lt;L7p:SetVariable&gt;
+                &lt;L7p:Base64Expression stringValue=&quot;YmFzaWM=&quot;/&gt;
+                &lt;L7p:VariableToSet stringValue=&quot;check_type&quot;/&gt;
+            &lt;/L7p:SetVariable&gt;
+        &lt;/wsp:OneOrMore&gt;
+        &lt;L7p:Encapsulated&gt;
+            &lt;L7p:EncapsulatedAssertionConfigGuid stringValue=&quot;357db91a-500e-41e9-b192-4990f9507ce9&quot;/&gt;
+            &lt;L7p:EncapsulatedAssertionConfigName stringValue=&quot;OTK Health Check&quot;/&gt;
+            &lt;L7p:NoOpIfConfigMissing booleanValue=&quot;true&quot;/&gt;
+        &lt;/L7p:Encapsulated&gt;
+        &lt;wsp:OneOrMore wsp:Usage=&quot;Required&quot;&gt;
+            &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
+                &lt;L7p:ComparisonAssertion&gt;
+                    &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                    &lt;L7p:Expression1 stringValue=&quot;${healthCheckError}&quot;/&gt;
+                    &lt;L7p:Expression2 stringValue=&quot;true&quot;/&gt;
+                    &lt;L7p:Predicates predicates=&quot;included&quot;&gt;
+                        &lt;L7p:item binary=&quot;included&quot;&gt;
+                            &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                            &lt;L7p:RightValue stringValue=&quot;true&quot;/&gt;
+                        &lt;/L7p:item&gt;
+                    &lt;/L7p:Predicates&gt;
+                &lt;/L7p:ComparisonAssertion&gt;
+                &lt;L7p:HardcodedResponse&gt;
+                    &lt;L7p:Base64ResponseBody stringValue=&quot;ewogICJlcnJvciI6ImludmFsaWRfcmVxdWVzdCIsCiAgImVycm9yX2Rlc2NyaXB0aW9uIjoiVGhlIHNlcnZlciBjb25maWd1cmF0aW9uIGlzIGludmFsaWQuIFNvbWUgZXJyb3Igb2NjdXJlZCBkdXJpbmcgT1RLIGhlYWx0aCBjaGVjay4gQ29udGFjdCB0aGUgYWRtaW5pc3RyYXRvciIKfQ==&quot;/&gt;
+                    &lt;L7p:ResponseContentType stringValue=&quot;application/json; charset=UTF-8&quot;/&gt;
+                    &lt;L7p:ResponseStatus stringValue=&quot;500&quot;/&gt;
+                &lt;/L7p:HardcodedResponse&gt;
+            &lt;/wsp:All&gt;
+            &lt;L7p:HardcodedResponse&gt;
+                &lt;L7p:Base64ResponseBody stringValue=&quot;b2s=&quot;/&gt;
+                &lt;L7p:ResponseContentType stringValue=&quot;application/text; charset=UTF-8&quot;/&gt;
+            &lt;/L7p:HardcodedResponse&gt;
+        &lt;/wsp:OneOrMore&gt;
+    &lt;/wsp:All&gt;
+&lt;/wsp:Policy&gt;
+                        </l7:Resource>
+                        </l7:ResourceSet>
+                    </l7:Resources>
+                </l7:Service>
+            </l7:Resource>
+        </l7:Item>
+    </l7:References>
+    <l7:Mappings>
+        <l7:Mapping action="NewOrUpdate" srcId="0000000000000000ffffffffffffec76" srcUri="https://localhost:8443/restman/1.0/folders/0000000000000000ffffffffffffec76" type="FOLDER">
+            <l7:Properties>
+                <l7:Property key="FailOnNew">
+                    <l7:BooleanValue>true</l7:BooleanValue>
+                </l7:Property>
+            </l7:Properties>
+        </l7:Mapping>
+        <l7:Mapping action="NewOrUpdate" srcId="2ace60fb68280f90e1919e6565c70e9c" srcUri="https://localhost:8443/restman/1.0/services/2ace60fb68280f90e1919e6565c70e9c" type="SERVICE"/>
+    </l7:Mappings>
+</l7:Bundle>

--- a/charts/gateway/bundles/otk-healthcheck.bundle
+++ b/charts/gateway/bundles/otk-healthcheck.bundle
@@ -5,7 +5,6 @@
             <l7:Name>OtkHealthCheck</l7:Name>
             <l7:Id>2ace60fb68280f90e1919e6565c70e9c</l7:Id>
             <l7:Type>SERVICE</l7:Type>
-            <l7:TimeStamp>2023-02-23T12:02:00.861Z</l7:TimeStamp>
             <l7:Resource>
                 <l7:Service id="2ace60fb68280f90e1919e6565c70e9c">
                     <l7:ServiceDetail folderId="0000000000000000ffffffffffffec76" id="2ace60fb68280f90e1919e6565c70e9c">
@@ -26,7 +25,6 @@
                             <l7:Property key="internal">
                                 <l7:BooleanValue>false</l7:BooleanValue>
                             </l7:Property>
-                            <l7:Property key="policyRevision">
                             <l7:Property key="soap">
                                 <l7:BooleanValue>false</l7:BooleanValue>
                             </l7:Property>
@@ -120,13 +118,6 @@
         </l7:Item>
     </l7:References>
     <l7:Mappings>
-        <l7:Mapping action="NewOrUpdate" srcId="0000000000000000ffffffffffffec76" srcUri="https://localhost:8443/restman/1.0/folders/0000000000000000ffffffffffffec76" type="FOLDER">
-            <l7:Properties>
-                <l7:Property key="FailOnNew">
-                    <l7:BooleanValue>true</l7:BooleanValue>
-                </l7:Property>
-            </l7:Properties>
-        </l7:Mapping>
-        <l7:Mapping action="NewOrUpdate" srcId="2ace60fb68280f90e1919e6565c70e9c" srcUri="https://localhost:8443/restman/1.0/services/2ace60fb68280f90e1919e6565c70e9c" type="SERVICE"/>
-    </l7:Mappings>
+        <l7:Mapping action="NewOrUpdate" srcId="2ace60fb68280f90e1919e6565c70e9c" srcUri="https://ae233fa70b0d:8443/restman/1.0/services/2ace60fb68280f90e1919e6565c70e9c" type="SERVICE"/>
+    </l7:Mappings>       
 </l7:Bundle>

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -485,27 +485,31 @@ otk:
     name: otk-health-check-bundle-config
 
   # OTK Specific configuration:
-  # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - The liveliness probe is not supported for OTK 4.6 & below versions.
+  # - Only valid for SINGLE and INTERNAL OTK types. Not be enabled for a DMZ OTK type.
+  # - In a dual gateway OTK setup, it is recomended enable liveness probe after the pods restart.
   # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
-  # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - The readinessProbe probe is not supported for OTK 4.6 & below versions.
+  # - Only valid for SINGLE and INTERNAL OTK types. Not be enabled for a DMZ OTK type.
+  # - In a dual gateway OTK setup, it is recomended enable readiness probe after the pods restart.
   # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -464,8 +464,8 @@ otk:
     password: 7layer
     properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # properties: {"localDataCenterName" : "DC1"}
-    sql:
-      jdbcURL: mysql://localhost:3306/otk_db
+    sql:      
+      jdbcURL: # jdbc:mysql://<host>:<port>/<database>
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:
@@ -476,25 +476,27 @@ otk:
     #   driverConfig: {"localDataCenterName" : "DC1"}
 
   # OTK Specific configuration:
+  # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
-  # Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
+  # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
-  # Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -464,8 +464,9 @@ otk:
     password: 7layer
     properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # properties: {"localDataCenterName" : "DC1"}
-    sql:      
-      jdbcURL: # jdbc:mysql://<host>:<port>/<database>
+    sql:
+      # jdbc:mysql://<host>:<port>/<database>
+      jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -465,7 +465,7 @@ otk:
     properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # properties: {"localDataCenterName" : "DC1"}
     sql:
-      # jdbc:mysql://<host>:<port>/<database>
+      # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
@@ -480,7 +480,7 @@ otk:
   # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
   # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otk-healthcheck.bundle
   healthCheckBundle:
-    enabled: fale
+    enabled: true
     useExisting: false
     name: otk-health-check-bundle-config
 
@@ -492,7 +492,7 @@ otk:
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
   livenessProbe:
-    enabled: false
+    enabled: true
     type: httpGet
     httpGet:
       path:
@@ -505,7 +505,7 @@ otk:
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
   readinessProbe:
-    enabled: false
+    enabled: true
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -476,6 +476,14 @@ otk:
     #   keyspace:
     #   driverConfig: {"localDataCenterName" : "DC1"}
 
+  # Install OTK Health check bundle on gateway. Uses config map.
+  # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
+  # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otk-healthcheck.bundle
+  healthCheckBundle:
+    enabled: fale
+    useExisting: false
+    name: otk-health-check-bundle-config
+
   # OTK Specific configuration:
   # - The liveliness probe is not supported for OTK 4.6 & below versions
   # - Should be enabled after otk installation.

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -450,7 +450,7 @@ otk:
   job:
     image:
       repository: caapim/otk-install
-      tag: 4.6.0
+      tag: 4.6.1
       pullPolicy: IfNotPresent
     labels: {}
     # nodeSelector: {}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -19,9 +19,6 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
-      annotations:
-        instrumentation.opentelemetry.io/inject-java: "true"
-        instrumentation.opentelemetry.io/container-names: "{{ .Chart.Name }}"
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.affinity }}
@@ -128,6 +125,10 @@ spec:
 {{- if .Values.bundle.enabled }}
             - name: {{ template "gateway.fullname" . }}-bundle-configmap
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/configmap
+{{- end }}
+{{- if and  (.Values.otk.enabled) (.Values.otk.healthCheckBundle.enabled) (not .Values.otk.healthCheckBundle.useExisting)}}
+            - name: {{ .Values.otk.healthCheckBundle.name }}
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/otkhealthcheck
 {{- end }}
 {{- if .Values.management.restman.enabled }}
             - name: {{ template "gateway.fullname" . }}-restman
@@ -375,6 +376,13 @@ spec:
             defaultMode: 292
             optional: false
             name: {{ template "gateway.fullname" . }}-bundle-configmap
+{{- end }}
+{{- if and  (.Values.otk.enabled) (.Values.otk.healthCheckBundle.enabled) (not .Values.otk.healthCheckBundle.useExisting) }}
+        - name: {{ .Values.otk.healthCheckBundle.name }}
+          configMap:
+            defaultMode: 292
+            optional: false
+            name: {{ .Values.otk.healthCheckBundle.name }}
 {{- end }}
 {{- if .Values.serviceMetrics.enabled }}
         - name: {{ template "gateway.fullname" . }}-service-metrics-configmap

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
+        instrumentation.opentelemetry.io/container-names: "{{ .Chart.Name }}"
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.affinity }}
@@ -228,8 +231,8 @@ spec:
 {{- if and (.Values.otk.enabled) (.Values.otk.livenessProbe.enabled) }}
 {{- if (eq .Values.otk.livenessProbe.type "httpGet" ) }}
             httpGet:
-              path: {{ .Values.otk.livenessProbe.path | default "/auth/oauth/health"}}
-              port: {{ .Values.otk.livenessProbe.port | default 8443 }}
+              path: {{ .Values.otk.livenessProbe.httpGet.path | default "/otk/health"}}
+              port: {{ .Values.otk.livenessProbe.httpGet.port | default 8443 }}
               scheme: {{ .Values.otk.livenessProbe.scheme | default "HTTPS" }}
 {{- else }}
             exec:
@@ -266,8 +269,8 @@ spec:
 {{- if and (.Values.otk.enabled) (.Values.otk.readinessProbe.enabled) }}
 {{- if (eq .Values.otk.readinessProbe.type "httpGet" ) }}
             httpGet:
-              path: {{ .Values.otk.readinessProbe.path | default "/auth/oauth/health"}}
-              port: {{ .Values.otk.readinessProbe.port | default 8443 }}
+              path: {{ .Values.otk.readinessProbe.httpGet.path | default "/otk/health"}}
+              port: {{ .Values.otk.readinessProbe.httpGet.port | default 8443 }}
               scheme: {{ .Values.otk.readinessProbe.scheme | default "HTTPS" }}
 {{- else }}
             exec:

--- a/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
+++ b/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
@@ -1,0 +1,145 @@
+{{ if and  (.Values.otk.enabled) (.Values.otk.healthCheckBundle.enabled) (not .Values.otk.healthCheckBundle.useExisting) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.otk.healthCheckBundle.name }}
+  labels:
+    app: {{ template "gateway.name" . }}
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  otkhealthCheck.bundle: |-
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+        <l7:References>
+            <l7:Item>
+                <l7:Name>OtkHealthCheck</l7:Name>
+                <l7:Id>2ace60fb68280f90e1919e6565c70e9c</l7:Id>
+                <l7:Type>SERVICE</l7:Type>
+                <l7:TimeStamp>2023-02-23T12:02:00.861Z</l7:TimeStamp>
+                <l7:Resource>
+                    <l7:Service id="2ace60fb68280f90e1919e6565c70e9c">
+                        <l7:ServiceDetail folderId="0000000000000000ffffffffffffec76" id="2ace60fb68280f90e1919e6565c70e9c">
+                            <l7:Name>OtkHealthCheck</l7:Name>
+                            <l7:Enabled>true</l7:Enabled>
+                            <l7:ServiceMappings>
+                                <l7:HttpMapping>
+                                    <l7:UrlPattern>/otk/health</l7:UrlPattern>
+                                    <l7:Verbs>
+                                        <l7:Verb>GET</l7:Verb>
+                                    </l7:Verbs>
+                                </l7:HttpMapping>
+                            </l7:ServiceMappings>
+                            <l7:Properties>
+                                <l7:Property key="hasRouting">
+                                    <l7:BooleanValue>true</l7:BooleanValue>
+                                </l7:Property>
+                                <l7:Property key="internal">
+                                    <l7:BooleanValue>false</l7:BooleanValue>
+                                </l7:Property>
+                                <l7:Property key="policyRevision">
+                                <l7:Property key="soap">
+                                    <l7:BooleanValue>false</l7:BooleanValue>
+                                </l7:Property>
+                                <l7:Property key="tracingEnabled">
+                                    <l7:BooleanValue>false</l7:BooleanValue>
+                                </l7:Property>
+                                <l7:Property key="wssProcessingEnabled">
+                                    <l7:BooleanValue>false</l7:BooleanValue>
+                                </l7:Property>
+                            </l7:Properties>
+                        </l7:ServiceDetail>
+                        <l7:Resources>
+                            <l7:ResourceSet tag="policy">
+                                <l7:Resource type="policy">&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+    &lt;wsp:Policy xmlns:L7p=&quot;http://www.layer7tech.com/ws/policy&quot; xmlns:wsp=&quot;http://schemas.xmlsoap.org/ws/2002/12/policy&quot;&gt;
+        &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
+            &lt;L7p:SslAssertion/&gt;
+            &lt;L7p:RemoteIpAddressRange&gt;
+                &lt;L7p:NetworkMask stringValue=&quot;16&quot;/&gt;
+                &lt;L7p:StartIp stringValue=&quot;240.224.2.1&quot;/&gt;
+            &lt;/L7p:RemoteIpAddressRange&gt;
+            &lt;L7p:SetVariable&gt;
+                &lt;L7p:Base64Expression stringValue=&quot;YWR2YW5jZWQ=&quot;/&gt;
+                &lt;L7p:VariableToSet stringValue=&quot;check_type&quot;/&gt;
+            &lt;/L7p:SetVariable&gt;
+            &lt;L7p:SetVariable&gt;
+                &lt;L7p:Base64Expression stringValue=&quot;JHtyZXF1ZXN0Lmh0dHAucGFyYW1ldGVyLmNsaWVudF9pZH0=&quot;/&gt;
+                &lt;L7p:VariableToSet stringValue=&quot;client_id&quot;/&gt;
+            &lt;/L7p:SetVariable&gt;
+            &lt;L7p:SetVariable&gt;
+                &lt;L7p:Base64Expression stringValue=&quot;JHtyZXF1ZXN0Lmh0dHAucGFyYW1ldGVyLmFwaWtleX0=&quot;/&gt;
+                &lt;L7p:VariableToSet stringValue=&quot;api_key&quot;/&gt;
+            &lt;/L7p:SetVariable&gt;
+            &lt;wsp:OneOrMore wsp:Usage=&quot;Required&quot;&gt;
+                &lt;L7p:ComparisonAssertion&gt;
+                    &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                    &lt;L7p:Expression1 stringValue=&quot;${request.http.parameter.check_type}&quot;/&gt;
+                    &lt;L7p:ExpressionIsVariable booleanValue=&quot;false&quot;/&gt;
+                    &lt;L7p:Operator operatorNull=&quot;null&quot;/&gt;
+                    &lt;L7p:Predicates predicates=&quot;included&quot;&gt;
+                        &lt;L7p:item dataType=&quot;included&quot;&gt;
+                            &lt;L7p:Type variableDataType=&quot;string&quot;/&gt;
+                        &lt;/L7p:item&gt;
+                        &lt;L7p:item binary=&quot;included&quot;&gt;
+                            &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                            &lt;L7p:RightValue stringValue=&quot;advanced&quot;/&gt;
+                        &lt;/L7p:item&gt;
+                    &lt;/L7p:Predicates&gt;
+                &lt;/L7p:ComparisonAssertion&gt;
+                &lt;L7p:SetVariable&gt;
+                    &lt;L7p:Base64Expression stringValue=&quot;YmFzaWM=&quot;/&gt;
+                    &lt;L7p:VariableToSet stringValue=&quot;check_type&quot;/&gt;
+                &lt;/L7p:SetVariable&gt;
+            &lt;/wsp:OneOrMore&gt;
+            &lt;L7p:Encapsulated&gt;
+                &lt;L7p:EncapsulatedAssertionConfigGuid stringValue=&quot;357db91a-500e-41e9-b192-4990f9507ce9&quot;/&gt;
+                &lt;L7p:EncapsulatedAssertionConfigName stringValue=&quot;OTK Health Check&quot;/&gt;
+                &lt;L7p:NoOpIfConfigMissing booleanValue=&quot;true&quot;/&gt;
+            &lt;/L7p:Encapsulated&gt;
+            &lt;wsp:OneOrMore wsp:Usage=&quot;Required&quot;&gt;
+                &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
+                    &lt;L7p:ComparisonAssertion&gt;
+                        &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                        &lt;L7p:Expression1 stringValue=&quot;${healthCheckError}&quot;/&gt;
+                        &lt;L7p:Expression2 stringValue=&quot;true&quot;/&gt;
+                        &lt;L7p:Predicates predicates=&quot;included&quot;&gt;
+                            &lt;L7p:item binary=&quot;included&quot;&gt;
+                                &lt;L7p:CaseSensitive booleanValue=&quot;false&quot;/&gt;
+                                &lt;L7p:RightValue stringValue=&quot;true&quot;/&gt;
+                            &lt;/L7p:item&gt;
+                        &lt;/L7p:Predicates&gt;
+                    &lt;/L7p:ComparisonAssertion&gt;
+                    &lt;L7p:HardcodedResponse&gt;
+                        &lt;L7p:Base64ResponseBody stringValue=&quot;ewogICJlcnJvciI6ImludmFsaWRfcmVxdWVzdCIsCiAgImVycm9yX2Rlc2NyaXB0aW9uIjoiVGhlIHNlcnZlciBjb25maWd1cmF0aW9uIGlzIGludmFsaWQuIFNvbWUgZXJyb3Igb2NjdXJlZCBkdXJpbmcgT1RLIGhlYWx0aCBjaGVjay4gQ29udGFjdCB0aGUgYWRtaW5pc3RyYXRvciIKfQ==&quot;/&gt;
+                        &lt;L7p:ResponseContentType stringValue=&quot;application/json; charset=UTF-8&quot;/&gt;
+                        &lt;L7p:ResponseStatus stringValue=&quot;500&quot;/&gt;
+                    &lt;/L7p:HardcodedResponse&gt;
+                &lt;/wsp:All&gt;
+                &lt;L7p:HardcodedResponse&gt;
+                    &lt;L7p:Base64ResponseBody stringValue=&quot;b2s=&quot;/&gt;
+                    &lt;L7p:ResponseContentType stringValue=&quot;application/text; charset=UTF-8&quot;/&gt;
+                &lt;/L7p:HardcodedResponse&gt;
+            &lt;/wsp:OneOrMore&gt;
+        &lt;/wsp:All&gt;
+    &lt;/wsp:Policy&gt;
+                            </l7:Resource>
+                            </l7:ResourceSet>
+                        </l7:Resources>
+                    </l7:Service>
+                </l7:Resource>
+            </l7:Item>
+        </l7:References>
+        <l7:Mappings>
+            <l7:Mapping action="NewOrUpdate" srcId="0000000000000000ffffffffffffec76" srcUri="https://localhost:8443/restman/1.0/folders/0000000000000000ffffffffffffec76" type="FOLDER">
+                <l7:Properties>
+                    <l7:Property key="FailOnNew">
+                        <l7:BooleanValue>true</l7:BooleanValue>
+                    </l7:Property>
+                </l7:Properties>
+            </l7:Mapping>
+            <l7:Mapping action="NewOrUpdate" srcId="2ace60fb68280f90e1919e6565c70e9c" srcUri="https://localhost:8443/restman/1.0/services/2ace60fb68280f90e1919e6565c70e9c" type="SERVICE"/>
+        </l7:Mappings>
+    </l7:Bundle>
+{{ end }}

--- a/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
+++ b/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
@@ -17,7 +17,6 @@ data:
                 <l7:Name>OtkHealthCheck</l7:Name>
                 <l7:Id>2ace60fb68280f90e1919e6565c70e9c</l7:Id>
                 <l7:Type>SERVICE</l7:Type>
-                <l7:TimeStamp>2023-02-23T12:02:00.861Z</l7:TimeStamp>
                 <l7:Resource>
                     <l7:Service id="2ace60fb68280f90e1919e6565c70e9c">
                         <l7:ServiceDetail folderId="0000000000000000ffffffffffffec76" id="2ace60fb68280f90e1919e6565c70e9c">
@@ -38,7 +37,6 @@ data:
                                 <l7:Property key="internal">
                                     <l7:BooleanValue>false</l7:BooleanValue>
                                 </l7:Property>
-                                <l7:Property key="policyRevision">
                                 <l7:Property key="soap">
                                     <l7:BooleanValue>false</l7:BooleanValue>
                                 </l7:Property>
@@ -132,13 +130,6 @@ data:
             </l7:Item>
         </l7:References>
         <l7:Mappings>
-            <l7:Mapping action="NewOrUpdate" srcId="0000000000000000ffffffffffffec76" srcUri="https://localhost:8443/restman/1.0/folders/0000000000000000ffffffffffffec76" type="FOLDER">
-                <l7:Properties>
-                    <l7:Property key="FailOnNew">
-                        <l7:BooleanValue>true</l7:BooleanValue>
-                    </l7:Property>
-                </l7:Properties>
-            </l7:Mapping>
             <l7:Mapping action="NewOrUpdate" srcId="2ace60fb68280f90e1919e6565c70e9c" srcUri="https://localhost:8443/restman/1.0/services/2ace60fb68280f90e1919e6565c70e9c" type="SERVICE"/>
         </l7:Mappings>
     </l7:Bundle>

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -41,11 +41,11 @@ spec:
              value: {{ required "Please fill in otk.database.connectionName in values.yaml" .Values.otk.database.connectionName | quote }}
 {{ if eq .Values.otk.database.type "cassandra" }}
            - name: OTK_CASSANDRA_CONNECTION_POINTS
-             value: {{ required "Please fill in otk.database.cassandra.jdbcURL in values.yaml" .Values.otk.database.cassandra.connectionPoints | quote }}
+             value: {{ required "Please fill in otk.database.cassandra.connectionPoints in values.yaml" .Values.otk.database.cassandra.connectionPoints | quote }}
            - name: OTK_CASSANDRA_PORT
-             value: {{ required "Please fill in otk.database.cassandra.jdbcDriverClass in values.yaml" .Values.otk.database.cassandra.port | quote }}
+             value: {{ required "Please fill in otk.database.cassandra.port in values.yaml" .Values.otk.database.cassandra.port | quote }}
            - name: OTK_CASSANDRA_KEYSPACE
-             value: {{ required "Please fill in otk.database.cassandra.jdbcURL in values.yaml" .Values.otk.database.cassandra.keySpace | quote }}
+             value: {{ required "Please fill in otk.database.cassandra.keyspace in values.yaml" .Values.otk.database.cassandra.keyspace | quote }}
            - name: OTK_CASSANDRA_DRIVER_CONFIG
              value: {{ default "na" .Values.otk.database.cassandra.driverConfig | toJson | b64enc| quote }}
 {{ end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -425,6 +425,7 @@ service:
 # Prerequisites.
 #  1. OTK DB is installed.
 #  2. restman is enabled. Can be disabled once the install/upgrage is complete (management.restman.enabled: true)
+# Note: In dual gateway installation, restart the pods after OTK install or upgrade.
 otk:
   enabled: false
   # OTK installation type - SINGLE, DMZ or INTERNAL
@@ -487,27 +488,31 @@ otk:
     name: otk-health-check-bundle-config
 
   # OTK Specific configuration:
-  # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - The liveliness probe is not supported for OTK 4.6 & below versions. 
+  # - Only valid for SINGLE and INTERNAL OTK types. Not be enabled for a DMZ OTK type.
+  # - In a dual gateway OTK setup, it is recomended enable liveness probe after the pods restart.
   # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
-  # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - The readinessProbe probe is not supported for OTK 4.6 & below versions.
+  # - Only valid for SINGLE and INTERNAL OTK types. Not be enabled for a DMZ OTK type.
+  # - In a dual gateway OTK setup, it is recomended enable readiness probe after the pods restart.
   # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -466,7 +466,7 @@ otk:
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}
     sql:
-      # jdbc:mysql://<host>:<port>/<database>
+      # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
@@ -494,7 +494,7 @@ otk:
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
   livenessProbe:
-    enabled: false
+    enabled: true
     type: httpGet
     httpGet:
       path:
@@ -507,7 +507,7 @@ otk:
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
   readinessProbe:
-    enabled: false
+    enabled: true
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -465,8 +465,8 @@ otk:
     # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}
-    sql:
-      jdbcURL: mysql://localhost:3306/otk_db
+    sql:      
+      jdbcURL: # jdbc:mysql://<host>:<port>/<database>
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:
@@ -479,26 +479,26 @@ otk:
 
   # OTK Specific configuration:
   # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
-  # Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
   # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
-  # Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -478,6 +478,14 @@ otk:
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     #   driverConfig: {"localDataCenterName" : "DC1"}
 
+  # Install OTK Health check bundle on gateway. Uses config map.
+  # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
+  # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otkhealthcheck.bundle
+  healthCheckBundle:
+    enabled: true
+    useExisting: false
+    name: otk-health-check-bundle-config
+
   # OTK Specific configuration:
   # - The liveliness probe is not supported for OTK 4.6 & below versions
   # - Should be enabled after otk installation.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -465,8 +465,9 @@ otk:
     # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}
-    sql:      
-      jdbcURL: # jdbc:mysql://<host>:<port>/<database>
+    sql:
+      # jdbc:mysql://<host>:<port>/<database>
+      jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -488,7 +488,7 @@ otk:
     name: otk-health-check-bundle-config
 
   # OTK Specific configuration:
-  # - The liveliness probe is not supported for OTK 4.6 & below versions. 
+  # - The liveliness probe is not supported for OTK 4.6 & below versions.
   # - Only valid for SINGLE and INTERNAL OTK types. Not be enabled for a DMZ OTK type.
   # - In a dual gateway OTK setup, it is recomended enable liveness probe after the pods restart.
   # - Should be enabled after otk installation.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -450,7 +450,7 @@ otk:
   job:
     image:
       repository: caapim/otk-install
-      tag: 4.6.0
+      tag: 4.6.1
       pullPolicy: IfNotPresent
     labels: {}
     # nodeSelector: {}


### PR DESCRIPTION
**Description of the change**

OTK Version 4.6.1
Support OTK Health check using service bundle. Removes need to do helm upgrade with health checks enabled after OTK install. The health check service will pass even when OTK is not yet installed.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

