### PR TITLE
Fix and update doc w.r.t otk health check

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.5
+version: 3.0.6
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -399,11 +399,11 @@ database:
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
 | `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
-| `otk.livenessProbe.enabled`                |  Enable/Disable Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete | `false`
+| `otk.livenessProbe.enabled`                | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1 | `false`
 | `otk.livenessProbe.type`                   |  | `httpGet`
 | `otk.livenessProbe.httpGet.path`           |  | `/auth/oauth/health`
 | `otk.livenessProbe.httpGet.port`           |  | `8443`
-| `otk.readinessProbe.enabled`               | Enable/Disable Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete  | `false`
+| `otk.readinessProbe.enabled`               | Enable/Disable. Should be enabled only after OTK installation is complete and OTK version >= 4.6.1 | `false`
 | `otk.readinessProbe.type`                  |  | `httpGet`
 | `otk.readinessProbe.httpGet.path`          |  | `/auth/oauth/health`
 | `otk.readinessProbe.httpGet.port`          |  | `8443`

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -465,7 +465,8 @@ otk:
     properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # properties: {"localDataCenterName" : "DC1"}
     sql:
-      jdbcURL: mysql://localhost:3306/otk_db
+      # jdbc:mysql://<host>:<port>/<database>
+      jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:
@@ -476,25 +477,27 @@ otk:
     #   driverConfig: {"localDataCenterName" : "DC1"}
 
   # OTK Specific configuration:
+  # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
-  # Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
+  # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
-  # Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -466,7 +466,8 @@ otk:
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}
     sql:
-      jdbcURL: mysql://localhost:3306/otk_db
+      # jdbc:mysql://<host>:<port>/<database>
+      jdbcURL:
       jdbcDriverClass: com.l7tech.jdbc.mysql.MySQLDriver
       # Oracle database name
       # databaseName:
@@ -479,26 +480,26 @@ otk:
 
   # OTK Specific configuration:
   # - The liveliness probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.livenessProbe.type as httpGet
   # - otk.livenessProbe.path /auth/oauth/health
   # - otk.livenessProbe.port 8443
   # - otk.livenessProbe.scheme https
-  # Have a higher initialDelaySeconds for livenessProbe when OTK is included to allow OTK installation job to complete
   livenessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:
       port:
   # OTK Specific configuration:
   # - The readinessProbe probe is not supported for OTK 4.6 & below versions
+  # - Should be enabled after otk installation.
   # - otk.readinessProbe.type as httpGet
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
-  # Have a higher initialDelaySeconds for readinessProbe when OTK is included to allow OTK installation job to complete
   readinessProbe:
-    enabled: true
+    enabled: false
     type: httpGet
     httpGet:
       path:


### PR DESCRIPTION
**Description of the change**

The OTK health check should enabled only once the OTK installation is complete as the health service is packaged as part of OTK. Also the health service is part of OTK 4.6.1 release. Hence by default the OTK health checks should be enabled false.


**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

