### PR TITLE
[DE562248] If Gateway readinessProbe checks for path /ssg/ping , then basic authentication is required as httpHeader

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.6
+version: 3.0.7
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -512,11 +512,6 @@ otk:
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
 
-  # Gateway Specific configuration:
-  # - if changed to service foo which is pre-installed via bundles
-  # - readinessProbe.type as httpGet
-  # - readinessProbe.path /foo
-  # - readinessProbe.port 8443
 
   readinessProbe:
     enabled: false
@@ -652,6 +647,14 @@ livenessProbe:
   periodSeconds: 15
   successThreshold: 1
   failureThreshold: 15
+
+
+# Gateway Specific configuration:
+# - when readinessProbe checks for path /ssg/ping , then basic authentication is required as httpHeader
+# httpHeaders:
+# - name: Authorization
+#   value: Basic <(.Values.management.username .Values.management.password)|b64enc>
+
 
 readinessProbe:
   enabled: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -511,6 +511,13 @@ otk:
   # - otk.readinessProbe.path /auth/oauth/health
   # - otk.readinessProbe.port 8443
   # - otk.readinessProbe.scheme https
+
+  # Gateway Specific configuration:
+  # - if changed to service foo which is pre-installed via bundles
+  # - readinessProbe.type as httpGet
+  # - readinessProbe.path /foo
+  # - readinessProbe.port 8443
+
   readinessProbe:
     enabled: false
     type: httpGet


### PR DESCRIPTION
…

**Description of the change**

Adding Gateway Specific configuration for readinessProbe if changed to o service foo which is pre-installed via bundles.

**Benefits**
By Default, Gateway readinessProbe points to /opt/docker/rc.d/diagnostic/health_check.sh , which ckecks container health not Gateway

 updating readinessProbe to service foo will be able to check when Gateway is ready to accept the traffic

**Drawbacks**

Gateway takes more than 40 sec(initialDelaySeconds)  to be ready to accept traffic , which means readinessProbe check might fail few times before it gets first success

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

