### PR TITLE
[charts/gateway-otk] Escape JdbcUrl parameters in bundle file

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 1.0.4
+version: 1.0.5
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 dependencies:

--- a/charts/gateway-otk/bundles/jdbc-connection-oauth.bundle
+++ b/charts/gateway-otk/bundles/jdbc-connection-oauth.bundle
@@ -12,7 +12,7 @@
                     <l7:Enabled>true</l7:Enabled>
                     <l7:Extension>
                         <l7:DriverClass>{{ .Values.installSolutionKits.otkJdbcDriver }}</l7:DriverClass>
-                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl | replace "\&" "\&amp;" }}</l7:JdbcUrl>
+                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl | replace "&" "&amp;" }}</l7:JdbcUrl>
                         <l7:ConnectionProperties>
                             <l7:Property key="password">
                                 <l7:StringValue>{{ .Values.installSolutionKits.otkJdbcPassword }}</l7:StringValue>

--- a/charts/gateway-otk/bundles/jdbc-connection-oauth.bundle
+++ b/charts/gateway-otk/bundles/jdbc-connection-oauth.bundle
@@ -12,7 +12,7 @@
                     <l7:Enabled>true</l7:Enabled>
                     <l7:Extension>
                         <l7:DriverClass>{{ .Values.installSolutionKits.otkJdbcDriver }}</l7:DriverClass>
-                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl }}</l7:JdbcUrl>
+                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl | replace "\&" "\&amp;" }}</l7:JdbcUrl>
                         <l7:ConnectionProperties>
                             <l7:Property key="password">
                                 <l7:StringValue>{{ .Values.installSolutionKits.otkJdbcPassword }}</l7:StringValue>

--- a/charts/gateway-otk/bundles/ssg-sts-install.bundle
+++ b/charts/gateway-otk/bundles/ssg-sts-install.bundle
@@ -13,7 +13,7 @@
                     <l7:Enabled>true</l7:Enabled>
                     <l7:Extension>
                         <l7:DriverClass>{{ .Values.installSolutionKits.otkJdbcDriver }}</l7:DriverClass>
-                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl }}</l7:JdbcUrl>
+                        <l7:JdbcUrl>{{ .Values.installSolutionKits.otkJdbcUrl | replace "&" "&amp;" }}</l7:JdbcUrl>
                         <l7:ConnectionProperties>
                             <l7:Property key="password">
                                 <l7:StringValue>{{ .Values.installSolutionKits.otkJdbcPassword }}</l7:StringValue>


### PR DESCRIPTION
This PR ensures that arguments passed as part of the JDBC connectiioin  string are properly escaped when inserted into bunndle files. For example, jdbc-connection-oauth.bundle should read:

```
<l7:JdbcUrl>jdbc:mysql://dbserver:3306/test_1otk1_otk_db?useSSL=true&amp;requireSSL=true&amp;verifyServerCertificate=false</l7:JdbcUrl>
```
iinsntead of:
```
<l7:JdbcUrl>jdbc:mysql://dbserver:3306/test_1otk1_otk_db?useSSL=true&requireSSL=true&verifyServerCertificate=false</l7:JdbcUrl>
```

**Benefits**

This will allow OTK installatioins that use SSL to succeed

**Drawbacks**

Not a drawback, per se, but I wonder if this is complete? I don't know a lot about bundle files - are there other thingns that need to be escaped? Also, I assume I should open another PR against 'stable' after this?

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

