### PR TITLE
charts/gateway - updating bootstrap script

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.6
+version: 3.0.7
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,9 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.7 General Updates
+The bootstrap script has been updated to reflect changes to the Container Gateway's filesystem. The updates are currently limited to 10.1.00_CR3. Please see the [InitContainer Examples](https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples) for more info 
+
 ## 3.0.6 General Updates
 The default image tag in values.yaml and production-values.yaml for OTK updated to **4.6.1**. Support for liveness and readiness probes using OTK health check service. 
 
@@ -286,7 +289,6 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `podSecurityContext`    | [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)              | `[]` |
 | `containerSecurityContext`    | [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)          | `{}` |
 | `bootstrap.script.enabled`    | Enable the bootstrap script              | `false` |
-| `bootstrap.script.cleanup`    | Cleanup the /opt/docker/custom folder              | `false` |
 
 
 ## Port Configuration

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -38,7 +38,9 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
 ## 3.0.7 General Updates
-The bootstrap script has been updated to reflect changes to the Container Gateway's filesystem. The updates are currently limited to 10.1.00_CR3. Please see the [InitContainer Examples](https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples) for more info 
+The bootstrap script has been updated to reflect changes to the Container Gateway's filesystem. The updates are currently limited to 10.1.00_CR3. Please see the [InitContainer Examples](https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples) for more info .
+
+The PM Tagger image default version tag been updated to 1.0.1.
 
 ## 3.0.6 General Updates
 The default image tag in values.yaml and production-values.yaml for OTK updated to **4.6.1**. Support for liveness and readiness probes using OTK health check service. 
@@ -577,7 +579,7 @@ ingress:
 | `pmtagger.replicas`          | Replicas (you should never need more than one | `1`  |
 | `pmtagger.image.registry`          | Image Registry | `docker.io`  |
 | `pmtagger.image.repository`          | Image Repository | `layer7api/pm-tagger`  |
-| `pmtagger.image.tag`          | Image Tag | `1.0.0`  |
+| `pmtagger.image.tag`          | Image Tag | `1.0.1`  |
 | `pmtagger.image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `pmtagger.image.imagePullSecret.enabled`                | Use Image Pull secret - this uses the image pull secret configured for the API Gateway   | `false` |
 | `pmtagger.resources`                | Resources   | `see values.yaml` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -54,7 +54,7 @@ pmtagger:
   image:
     registry: docker.io
     repository: layer7api/pm-tagger
-    tag: 1.0.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -691,13 +691,12 @@ containerSecurityContext: {}
 bootstrap:
   script:
     enabled: false
-  cleanup: false
 
 # Add initContainers to the Gateway
 initContainers: []
 # initContainers:
 # - name: simple-init
-#   image: docker.io/layer7api/simple-init:1.0.0
+#   image: docker.io/layer7api/simple-init:1.0.1
 #   imagePullPolicy: Always
 #   volumeMounts:
 #   - name: config-directory

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -123,23 +123,23 @@ data:
     BUNDLE_DIR="$BASE_CONFIG_DIR/bundle"
     CUSTOM_ASSERTIONS_DIR="$BASE_CONFIG_DIR/custom-assertions"
     MODULAR_ASSERTIONS_DIR="$BASE_CONFIG_DIR/modular-assertions"
+    EXTERNAL_LIBRARIES_DIR="$BASE_CONFIG_DIR/external-libraries"
+    CUSTOM_PROPERTIES_DIR="$BASE_CONFIG_DIR/custom-properties"
+    CUSTOM_HEALTHCHECK_SCRIPTS_DIR="$BASE_CONFIG_DIR/health-checks"
     CUSTOM_SHELL_SCRIPTS_DIR="$BASE_CONFIG_DIR/scripts"
+
     BASE_TARGET_DIR="/opt/SecureSpan/Gateway"
-    TARGET_BUNDLE_DIR="$BASE_TARGET_DIR/node/default/etc/bootstrap/bundle"
     TARGET_CUSTOM_ASSERTIONS_DIR="$BASE_TARGET_DIR/runtime/modules/lib"
     TARGET_MODULAR_ASSERTIONS_DIR="$BASE_TARGET_DIR/runtime/modules/assertions"
+    TARGET_EXTERNAL_LIBRARIES_DIR="$BASE_TARGET_DIR/runtime/lib/ext"
+    TARGET_BUNDLE_DIR="$BASE_TARGET_DIR/node/default/etc/bootstrap/bundle"
+    TARGET_CUSTOM_PROPERTIES_DIR="$BASE_TARGET_DIR/node/default/etc/conf"
+    TARGET_HEALTHCHECK_DIR="/opt/docker/rc.d/diagnostic/health_check"
     
     error() {
             # Send errors to stderr in case these get handled differently by the container PaaS on which this runs
             echo "ERROR - ${1}" 1>&2
             exit 1
-    }
-
-    function cleanup() {
-      echo "***************************************************************************"
-      echo "removing $BASE_CONFIG_DIR"
-      echo "***************************************************************************"
-      rm -rf $BASE_CONFIG_DIR/*
     }
     
     function copy() {
@@ -168,7 +168,6 @@ data:
         FILES=$(find $3 -type f -name '*'$2 2>/dev/null)
         for file in $FILES; do
             name=$(basename "$file")
-            chmod +x $file
             echo -e "running $name"
             /bin/bash $file
             if [ $? -ne 0 ]; then
@@ -181,10 +180,11 @@ data:
     copy "bundles" ".bundle" $BUNDLE_DIR $TARGET_BUNDLE_DIR
     copy "custom assertions" ".jar" $CUSTOM_ASSERTIONS_DIR $TARGET_CUSTOM_ASSERTIONS_DIR
     copy "modular assertions" ".aar" $MODULAR_ASSERTIONS_DIR $TARGET_MODULAR_ASSERTIONS_DIR
+    copy "external libraries" ".jar" $EXTERNAL_LIBRARIES_DIR $TARGET_EXTERNAL_LIBRARIES_DIR
+    copy "custom properties" ".properties" $CUSTOM_PROPERTIES_DIR $TARGET_CUSTOM_PROPERTIES_DIR
+    copy "custom health checks" ".sh" $CUSTOM_HEALTHCHECK_SCRIPTS_DIR $TARGET_HEALTHCHECK_DIR
     run "custom shell scripts" ".sh" $CUSTOM_SHELL_SCRIPTS_DIR
-{{- if .Values.bootstrap.cleanup }}
-    cleanup
-{{- end}}
+
 {{- end}}
     
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -54,7 +54,7 @@ pmtagger:
   image:
     registry: docker.io
     repository: layer7api/pm-tagger
-    tag: 1.0.0
+    tag: 1.0.1
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -693,13 +693,12 @@ containerSecurityContext: {}
 bootstrap:
   script:
     enabled: false
-  cleanup: false
 
 # Add initContainers to the Gateway
 initContainers: []
 # initContainers:
 # - name: simple-init
-#   image: docker.io/layer7api/simple-init:1.0.0
+#   image: docker.io/layer7api/simple-init:1.0.1
 #   imagePullPolicy: Always
 #   volumeMounts:
 #   - name: config-directory


### PR DESCRIPTION
**Description of the change**

Gateway 10.1.00_CR3 introduces new folder permissions that allow files like external java libraries, .properties and healthcheck scripts to be loaded via initContainer. This change updates the optional bootstrap script that moves this configuration from /opt/docker/custom to the correct locations on the Gateway for startup.

**Benefits**
Further decreased reliance on derived images

**Drawbacks**
This change currently only benefits Gateway 10.1.00_CR3

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

