### PR TITLE
[charts/gateway] Jm665334 gw pdb

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.4
+version: 3.0.5
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.5
+version: 3.0.4
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -205,6 +205,9 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `imagePullSecret.existingSecretName`          | Point to an existing Image Pull Secret | `commented out`  |
 | `imagePullSecret.username`          | Registry Username | `nil`  |
 | `imagePullSecret.password`          | Registry Password | `nil`  |
+| `pdb.create`          | Create a PodDisruptionBudget (PDB) object | `false` |
+| `pdb.maxUnavailable`         | PodDisruptionBudget maximum unavailable pod count         |
+| `pdb.minAvailable`         | PodDisruptionBudget minimum available pod count          |
 | `replicas`                   | Number of Gateway replicas        | `1`                                                          |
 | `updateStrategy.type`             | Deployment Strategy                       | `RollingUpdate`                                              |
 | `updateStrategy.rollingUpdate.maxSurge`             | Rolling Update Max Surge                       | `1`                                              |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -31,6 +31,11 @@ imagePullSecret:
   username:
   password:
 
+pdb:
+  create: false
+  maxUnavailable: ""
+  minAvailable: 1
+
 serviceAccount:
   # name:
   create: true

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -34,7 +34,7 @@ imagePullSecret:
 pdb:
   create: false
   maxUnavailable: ""
-  minAvailable: 1
+  minAvailable: ""
 
 serviceAccount:
   # name:

--- a/charts/gateway/templates/pdb.yaml
+++ b/charts/gateway/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "gateway.fullname" . }}-pdb
+  name: {{ template "gateway.fullname" . }}-pdb
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "gateway.fullname" . }}
+{{ end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -35,7 +35,7 @@ imagePullSecret:
 pdb:
   create: false
   maxUnavailable: ""
-  minAvailable: 1
+  minAvailable: ""
 
 serviceAccount:
   # name:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -31,6 +31,12 @@ imagePullSecret:
   username:
   password:
 
+# Create PodDisruptionBudget
+pdb:
+  create: false
+  maxUnavailable: ""
+  minAvailable: 1
+
 serviceAccount:
   # name:
   create: true


### PR DESCRIPTION
**Description of the change**

**Benefits**

Users will be able to specify pod disruption budgets (PDBs) for their gateway deployments. I do not see drawbacks, given that PDBs are optional, and disabled by default.

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

