### PR TITLE
Update hazelcast version to 5.2.1

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 2.0.1
+version: 2.0.2
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:

--- a/charts/gateway-otk/templates/configmap.yaml
+++ b/charts/gateway-otk/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
         {{- else }}
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.1.xsd"
+         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.2.xsd"
         {{- end }}
             xmlns="http://www.hazelcast.com/schema/client-config">
         <instance-name>{{ .Release.Name }}-{{ .Release.Namespace }}</instance-name>

--- a/charts/gateway-otk/values.yaml
+++ b/charts/gateway-otk/values.yaml
@@ -286,7 +286,7 @@ hazelcast:
   external: false
   # url: hazelcast.example.com:5701
   image:
-    tag: "5.1.1"
+    tag: "5.2.1"
   cluster:
     memberCount: 2
   mancenter:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.7
+version: 3.0.8
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -921,7 +921,7 @@ The following table lists the configured parameters of the Hazelcast Subchart - 
 | -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
 | `hazelcast.enabled`                | Enable/Disable deployment of Hazelcast   | `false` |
 | `hazelcast.external`                | Point to an external Hazelcast - set enabled to false and configure the url  | `false` |
-| `hazelcast.image.tag`                | The Gateway currently supports Hazelcast 4.x/5.x servers.  | `5.1.1` |
+| `hazelcast.image.tag`                | The Gateway currently supports Hazelcast 4.x/5.x servers.  | `5.2.1` |
 | `hazelcast.url`                | External Hazelcast Url  | `hazelcast.example.com:5701` |
 | `hazelcast.cluster.memberCount`                | Number of Hazelcast Replicas you wish to deploy   | `see values.yaml` |
 | `hazelcast.hazelcast.yaml`                | Hazelcast configuration   | `see the documentation link` |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,10 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.8 Updates to Hazelcast
+The default image tag in values.yaml is updated to **5.2.1** and xsd version in configmap.yaml to **5.2**. The updates are due to vulnerability from CVE-2022-36437.
+The updates are applied to both the gateway and gateway-otk chart.
+
 ## 3.0.7 General Updates
 The bootstrap script has been updated to reflect changes to the Container Gateway's filesystem. The updates are currently limited to 10.1.00_CR3. Please see the [InitContainer Examples](https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples) for more info .
 

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -819,7 +819,7 @@ hazelcast:
   # url: hazelcast.example.com:5701
   image:
     repository: "hazelcast/hazelcast"
-    tag: "5.1.1"
+    tag: "5.2.1"
     pullPolicy: IfNotPresent
     # pullSecrets:
     # - myRegistryKeySecretName

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
         {{- else }}
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.1.xsd"
+         http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.2.xsd"
         {{- end }}
             xmlns="http://www.hazelcast.com/schema/client-config">
         <instance-name>{{ .Release.Name }}-{{ .Release.Namespace }}</instance-name>

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -821,7 +821,7 @@ hazelcast:
   # url: hazelcast.example.com:5701
   image:
     repository: "hazelcast/hazelcast"
-    tag: "5.1.1"
+    tag: "5.2.1"
     pullPolicy: IfNotPresent
     # pullSecrets:
     # - myRegistryKeySecretName


### PR DESCRIPTION
Update helm chart to use 5.2.1 due to CVE.

We've already upgraded hazelcast library to 5.2.1 on gateway due to [DE556720](https://rally1.rallydev.com/#/132472514092ud/custom/199537663468?detail=%2Fdefect%2F682609441983) and helm chart needs an update as well.
