### PR TITLE
charts/gateway adding additional configuration options for PM-tagger

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.8
+version: 3.0.9
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,13 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.9 Updates to PM-Tagger
+PM tagger has following additional configuration options
+- [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)
+- [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+- [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+- [All PM-Tagger Configuration](#pm-tagger-configuration)
+
 ## 3.0.8 Updates to Hazelcast
 The default image tag in values.yaml is updated to **5.2.1** and xsd version in configmap.yaml to **5.2**. The updates are due to vulnerability from CVE-2022-36437.
 The updates are applied to both the gateway and gateway-otk chart.
@@ -587,6 +594,12 @@ ingress:
 | `pmtagger.image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `pmtagger.image.imagePullSecret.enabled`                | Use Image Pull secret - this uses the image pull secret configured for the API Gateway   | `false` |
 | `pmtagger.resources`                | Resources   | `see values.yaml` |
+| `nodeSelector`    | [Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)              | `{}` |
+| `affinity`    | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)             | `{}` |
+| `topologySpreadConstraints`    | [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)             | `[]` |
+| `tolerations`    | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)              | `[]` |
+| `podSecurityContext`    | [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)              | `[]` |
+| `containerSecurityContext`    | [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)          | `{}` |
 
 ### Database Configuration
 You can configure the deployment to use an external database (this is the recommended approach - the included MySQL SubChart is not supported). In the values.yaml file, set the create field in the database section to false, and set jdbcURL to use your own database server:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -69,8 +69,19 @@ pmtagger:
   # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   # nodeSelector: {}
   # affinity: {}
+
+  # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods
+  topologySpreadConstraints: []
+  
   # ref:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
+  
+  # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext: {}
+  
+  # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
+
 
 # Cluster Hostname
 clusterHostname: my.localdomain

--- a/charts/gateway/templates/pm-tagger-deployment.yaml
+++ b/charts/gateway/templates/pm-tagger-deployment.yaml
@@ -29,6 +29,12 @@ spec:
       {{- if .Values.pmtagger.tolerations }}
       tolerations: {{- toYaml .Values.pmtagger.tolerations | nindent 12 }}
       {{- end }}
+      {{- if .Values.pmtagger.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml .Values.pmtagger.topologySpreadConstraints | nindent 12 }}
+      {{- end }}
+      {{- if .Values.pmtagger.podSecurityContext }}
+      securityContext: {{- toYaml .Values.pmtagger.podSecurityContext | nindent 12 }}
+      {{- end }}
       {{- if .Values.pmtagger.nodeSelector }}
       nodeSelector: {{- toYaml .Values.pmtagger.nodeSelector | nindent 12 }}
       {{- end }}
@@ -43,6 +49,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{.Values.pmtagger.image.registry}}/{{.Values.pmtagger.image.repository}}:{{.Values.pmtagger.image.tag}}
           imagePullPolicy: {{ .Values.pmtagger.image.pullPolicy }}
+          {{- if .Values.pmtagger.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.pmtagger.containerSecurityContext | nindent 12 }}
+          {{- end }}
           command:
           - /pm-tagger
           resources:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -69,8 +69,19 @@ pmtagger:
   # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   # nodeSelector: {}
   # affinity: {}
+
+  # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods
+  topologySpreadConstraints: []
+
   # ref:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
+
+  # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext: {}
+
+  # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  containerSecurityContext: {}
+
 
 # Cluster Hostname
 clusterHostname: my.localdomain


### PR DESCRIPTION
**Description of the change**
3.0.9 Updates to PM-Tagger
PM tagger has following additional configuration options
- [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)
- [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
- [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
- [All PM-Tagger Configuration](#pm-tagger-configuration)

**Benefits**
PM-Tagger runs as an arbitrary non-root uid by default. That uid may fall outside the range of restrictive pod security standards, making this configurable allows the deployment to adhere to enterprise specific rules. Additional configuration provides more flexibility for pod placement

**Drawbacks**
No drawbacks, all features are not configured by default

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

