### PR TITLE
charts/gateway updated custom label/annotations

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.9
+version: 3.0.10
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,42 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.10 General Updates
+Custom labels and annotations have been extended to all objects the Gateway Chart deploys. Pod Labels and annotations have been added to the Gateway and PM-Tagger deployments.
+
+- Additional Labels/Annotations apply to everything in this Chart's templates
+```
+# Additional Annotations apply to all deployed objects
+additionalAnnotations: {}
+
+# Additional Labels apply to all deployed objects
+additionalLabels: {}
+```
+
+- Pod Labels/Annotations at the base level apply to the Gateway Pod
+```
+## Pod Labels for the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# Pod Annotations apply to the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+```
+
+- PM-Tagger pod labels/annotations are separate
+```
+pmtagger:
+  ...
+  ## Pod Labels for the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # Pod Annotations apply to the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+```
+
 ## 3.0.9 Updates to PM-Tagger
 PM tagger has following additional configuration options
 - [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)
@@ -233,6 +269,10 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `imagePullSecret.existingSecretName`          | Point to an existing Image Pull Secret | `commented out`  |
 | `imagePullSecret.username`          | Registry Username | `nil`  |
 | `imagePullSecret.password`          | Registry Password | `nil`  |
+| `additionalAnnotations`          | Additional Annotations apply to all deployed objects | `{}`  |
+| `additionalLabels`          | Additional Labels apply to all deployed objects | `{}`  |
+| `podLabels`          | Pod Labels for the Gateway Pod | `{}`  |
+| `podAnnotations`          | Pod Annotations apply to the Gateway Pod | `{}`  |
 | `replicas`                   | Number of Gateway replicas        | `1`                                                          |
 | `updateStrategy.type`             | Deployment Strategy                       | `RollingUpdate`                                              |
 | `updateStrategy.rollingUpdate.maxSurge`             | Rolling Update Max Surge                       | `1`                                              |
@@ -594,12 +634,14 @@ ingress:
 | `pmtagger.image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `pmtagger.image.imagePullSecret.enabled`                | Use Image Pull secret - this uses the image pull secret configured for the API Gateway   | `false` |
 | `pmtagger.resources`                | Resources   | `see values.yaml` |
-| `nodeSelector`    | [Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)              | `{}` |
-| `affinity`    | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)             | `{}` |
-| `topologySpreadConstraints`    | [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)             | `[]` |
-| `tolerations`    | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)              | `[]` |
-| `podSecurityContext`    | [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)              | `[]` |
-| `containerSecurityContext`    | [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)          | `{}` |
+| `pmtagger.podLabels`          | Pod Labels for the Gateway Pod | `{}`  |
+| `pmtagger.podAnnotations`          | Pod Annotations apply to the Gateway Pod | `{}`  |
+| `pmtagger.nodeSelector`    | [Node Selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)              | `{}` |
+| `pmtagger.affinity`    | [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)             | `{}` |
+| `pmtagger.topologySpreadConstraints`    | [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods)             | `[]` |
+| `pmtagger.tolerations`    | [Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)              | `[]` |
+| `pmtagger.podSecurityContext`    | [Pod Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)              | `[]` |
+| `pmtagger.containerSecurityContext`    | [Container Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)          | `{}` |
 
 ### Database Configuration
 You can configure the deployment to use an external database (this is the recommended approach - the included MySQL SubChart is not supported). In the values.yaml file, set the create field in the database section to false, and set jdbcURL to use your own database server:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -31,6 +31,20 @@ imagePullSecret:
   username:
   password:
 
+# Additional Annotations apply to all deployed objects
+additionalAnnotations: {}
+
+# Additional Labels apply to all deployed objects
+additionalLabels: {}
+
+## Pod Labels for the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# Pod Annotations apply to the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
 serviceAccount:
   # name:
   create: true
@@ -66,6 +80,14 @@ pmtagger:
     limits:
       memory: 64Mi
       cpu: 250m
+  ## Pod Labels for the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # Pod Annotations apply to the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
   # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   # nodeSelector: {}
   # affinity: {}

--- a/charts/gateway/templates/bundle-configmap.yaml
+++ b/charts/gateway/templates/bundle-configmap.yaml
@@ -9,6 +9,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   {{- range $path, $_ :=  .Files.Glob  .Values.bundle.path }}
   {{ $path | replace "/" "-" }}: |-

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -7,6 +7,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+   {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   ACCEPT_LICENSE: {{ .Values.license.accept | quote}}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}

--- a/charts/gateway/templates/cwp-configmap.yaml
+++ b/charts/gateway/templates/cwp-configmap.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 {{- $hexArr := splitList " " (include "gateway.cwp.hex" .) }}
 data:
   cwp.bundle: |

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -7,6 +7,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -19,6 +28,15 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
+    {{- range $key, $val := .Values.podLabels }}
+        {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- if  .Values.podAnnotations }}
+      annotations:
+    {{- range $key, $val := .Values.podAnnotations }}
+        {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- end }}
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.affinity }}

--- a/charts/gateway/templates/grafana-configmap.yaml
+++ b/charts/gateway/templates/grafana-configmap.yaml
@@ -10,6 +10,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   {{- if .Values.grafana.customDashboard.value}}
   gateway-service-metrics.json: {{ .Values.grafana.customDashboard.value | toJson }}

--- a/charts/gateway/templates/grafana-secret.yaml
+++ b/charts/gateway/templates/grafana-secret.yaml
@@ -13,6 +13,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 type: Opaque
 stringData:
   datasources.yaml: |-

--- a/charts/gateway/templates/hpa.yaml
+++ b/charts/gateway/templates/hpa.yaml
@@ -12,6 +12,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 spec:
   behavior:
 {{ toYaml .Values.autoscaling.hpa.behavior | indent 4 }}

--- a/charts/gateway/templates/image-pull-secret.yaml
+++ b/charts/gateway/templates/image-pull-secret.yaml
@@ -3,6 +3,20 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "gateway.imagePullSecret" . }}
+  labels:
+    app: {{ template "gateway.name" . }}
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -11,6 +11,9 @@ metadata:
    chart: {{ template "gateway.chart" . }}
    release: {{ .Release.Name }}
    heritage: {{ .Release.Service }}
+   {{- range $key, $val := .Values.additionalLabels }}
+   {{ $key }}: "{{ $val }}"
+   {{- end }}
  annotations:
 {{- range $key, $val := .Values.ingress.annotations }}
    {{ $key }}: "{{ $val }}"

--- a/charts/gateway/templates/license-secret.yaml
+++ b/charts/gateway/templates/license-secret.yaml
@@ -5,11 +5,17 @@ metadata:
   name: {{ template "gateway.license" . }}
   annotations:
     description: Template for Secrets for the Gateway license
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
   labels:
     app: {{ template "gateway.name" . }}
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
 type: Opaque
 data:
   license: {{ required "Please provide a Layer7 Gateway license, if you aren't sure contact your Broadcom Sales Representative" .Values.license.value | b64enc | quote }}

--- a/charts/gateway/templates/listenport-configmap.yaml
+++ b/charts/gateway/templates/listenport-configmap.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 {{- $hexArr := splitList " " (include "gateway.listenPort.hex" .) }}
 data:
   listenPort.bundle: |-

--- a/charts/gateway/templates/management-service.yaml
+++ b/charts/gateway/templates/management-service.yaml
@@ -6,6 +6,9 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
   name: {{ template "gateway.fullname" . }}-management
   annotations:
     description: "The Gateway Management service"

--- a/charts/gateway/templates/otk-db-secret.yaml
+++ b/charts/gateway/templates/otk-db-secret.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 type: Opaque
 data:
   OTK_DATABASE_PASSWORD : {{ required "Please fill in otk.database.password in values.yaml" .Values.otk.database.password | b64enc }}

--- a/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
+++ b/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   otkhealthCheck.bundle: |-
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -15,6 +15,15 @@ metadata:
     {{- range $key, $val := .Values.otk.job.labels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 spec:
   backoffLimit: 1
   template:

--- a/charts/gateway/templates/pm-tagger-configmap.yaml
+++ b/charts/gateway/templates/pm-tagger-configmap.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   config.yaml: |
     version: {{ .Values.pmtagger.image.tag }}

--- a/charts/gateway/templates/pm-tagger-deployment.yaml
+++ b/charts/gateway/templates/pm-tagger-deployment.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 spec:
   selector:
     matchLabels:
@@ -21,6 +30,15 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}-pm-tagger
         release: {{ .Release.Name }}
+    {{- range $key, $val := .Values.pmtagger.podLabels }}
+        {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- if  .Values.pmtagger.podAnnotations }}
+      annotations:
+    {{- range $key, $val := .Values.pmtagger.podAnnotations }}
+        {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- end }}
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.pmtagger.affinity }}

--- a/charts/gateway/templates/pm-tagger-role.yaml
+++ b/charts/gateway/templates/pm-tagger-role.yaml
@@ -7,6 +7,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/gateway/templates/pm-tagger-rolebinding.yaml
+++ b/charts/gateway/templates/pm-tagger-rolebinding.yaml
@@ -7,6 +7,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "gateway.serviceAccountName" . }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 type: Opaque
 data:
   SSG_ADMIN_USERNAME: {{ .Values.management.username | b64enc }}

--- a/charts/gateway/templates/service-account.yaml
+++ b/charts/gateway/templates/service-account.yaml
@@ -6,12 +6,18 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-9"
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "gateway.name" . }}
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
 secrets:
   - name: {{ include "gateway.fullname" . }}
 {{ end }}

--- a/charts/gateway/templates/service-metrics-configmap.yaml
+++ b/charts/gateway/templates/service-metrics-configmap.yaml
@@ -8,6 +8,15 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  annotations:
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
 data:
   cwp.bundle: |
     <l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
   name: {{ template "gateway.fullname" . }}
   annotations:
     description: "The Gateway service"

--- a/charts/gateway/templates/ssl-secret.yaml
+++ b/charts/gateway/templates/ssl-secret.yaml
@@ -5,11 +5,17 @@ metadata:
   name: {{ template "gateway.tlsSecretName" . }}
   annotations:
     description: Default SSL Key for the SSG Gateway
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
   labels:
     app: {{ template "gateway.name" . }}
     chart: {{ template "gateway.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
 type: Opaque
 data:
   SSG_SSL_KEY: {{ .Values.tls.key | b64enc | b64enc }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -31,6 +31,20 @@ imagePullSecret:
   username:
   password:
 
+# Additional Annotations apply to all deployed objects
+additionalAnnotations: {}
+
+# Additional Labels apply to all deployed objects
+additionalLabels: {}
+
+## Pod Labels for the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+# Pod Annotations apply to the Gateway Pod
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
 serviceAccount:
   # name:
   create: true
@@ -66,6 +80,14 @@ pmtagger:
     limits:
       memory: 64Mi
       cpu: 250m
+  ## Pod Labels for the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # Pod Annotations apply to the PM Tagger Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
   # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   # nodeSelector: {}
   # affinity: {}


### PR DESCRIPTION
**Description of the change**
Custom labels and annotations have been extended to all objects the Gateway Chart deploys. Pod Labels and annotations have been added to the Gateway and PM-Tagger deployments.

- Additional Labels/Annotations apply to everything in this Chart's templates
```
# Additional Annotations apply to all deployed objects
additionalAnnotations: {}

# Additional Labels apply to all deployed objects
additionalLabels: {}
```

- Pod Labels/Annotations at the base level apply to the Gateway Pod
```
## Pod Labels for the Gateway Pod
## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
podLabels: {}

# Pod Annotations apply to the Gateway Pod
## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
podAnnotations: {}
```

- PM-Tagger pod labels/annotations are separate
```
pmtagger:
  ...
  ## Pod Labels for the PM Tagger Pod
  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
  podLabels: {}

  # Pod Annotations apply to the PM Tagger Pod
  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
  podAnnotations: {}
```

**Drawbacks**
No known drawbacks

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

