### PR TITLE
charts/gateway added gateway container lifecycle configuration

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.10
+version: 3.0.11
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -94,45 +94,34 @@ pmtagger:
 
   # ref:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraints-for-pods
   topologySpreadConstraints: []
-  
+
   # ref:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
-  
+
   # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   podSecurityContext: {}
-  
+
   # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
 
+# Override all lifecycle hooks. This will take precedence over the preStopScript section below.
+lifecycleHooks: {}
+  # postStart: {}
+  # preStop: {}
 
-# Cluster Hostname
-clusterHostname: my.localdomain
+# This preStop script checks for open connections and delays pod termination for the specified timeout seconds
+# Enabling this mounts the script to /opt/docker/gracefulshutdown.sh and adds a preStop lifecycle hook to the Gateway Deployment
+preStopScript:
+  enabled: false        # Enable/Disable
+  periodSeconds: 3      # Time between checks
+  timeoutSeconds: 60    # Timeout - must be lower than terminationGracePeriodSeconds
+  excludedPorts:
+  - 2124
+  - 8777
 
-# Database configuration
-database:
-  # DB Backed or ephemeral
-  enabled: true
-  # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
-  # Do not use this demo database in production!!!
-  create: false
-  # jdbcURL: jdbc:mysql://<host>:<port>/<database> | jdbc:mysql://<host>:<port>,<host>:<port>/<database>,...
-  # Configurable, update the mysql.auth.<settings> if you change this and would like to use the demo database server.
-  username: gateway
-  password: mypassword
-  name: ssg
-
-## If loading a TLS Key/Pair
-# This key will become the default ssl key. Can only have one.
-# use with helm command: --set-file tls.key=/path/to/ssl.p12 --set tls.pass=keypass
-## Reference an existing secret for the Gateway Private Key, the secret needs to contain the following.
-  # SSG_SSL_KEY - decoded value needs to be base64 encoded. (cat ssl.p12 | base64 --wrap=0)
-  # SSG_SSL_KEY_PASS
-tls:
-  useSignedCertificates: false
-  # existingSecretName: ssg-tls
-# It is not recommendeded to load private keys in values.yaml, use an existingTlsSecret.
-  key:
-  pass:
+## terminationGracePeriodSeconds default duration in seconds kubernetes waits for container to exit before sending kill signal.
+## Defaults to 30 if not set
+# terminationGracePeriodSeconds: 90
 
 # Configure autoscaling
 # this makes use of autoscaling/v2beta2 and autoscaling/v2 for v1.23 and later
@@ -249,8 +238,8 @@ config:
         # privateKey: 00000000000000000000000000000002:ssl
           clientAuthentication: Optional
           versions:
-          # - TLSv1.0
-          # - TLSv1.1
+        # - TLSv1.0
+        # - TLSv1.1
           - TLSv1.2
           - TLSv1.3
           useCipherSuitesOrder: true
@@ -310,8 +299,8 @@ config:
         # privateKey: 00000000000000000000000000000002:ssl
           clientAuthentication: Optional
           versions:
-          # - TLSv1.0
-          # - TLSv1.1
+        # - TLSv1.0
+        # - TLSv1.1
           - TLSv1.2
           - TLSv1.3
           useCipherSuitesOrder: true
@@ -378,6 +367,35 @@ config:
 ## If using a Database
   # SSG_DATABASE_USER
   # SSG_DATABASE_PASSWORD
+
+# Cluster Hostname
+clusterHostname: my.localdomain
+
+# Database configuration
+database:
+  # DB Backed or ephemeral
+  enabled: true
+  # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
+  # Do not use this demo database in production!!!
+  create: false
+  # jdbcURL: jdbc:mysql://<host>:<port>/<database> | jdbc:mysql://<host>:<port>,<host>:<port>/<database>,...
+  # Configurable, update the mysql.auth.<settings> if you change this and would like to use the demo database server.
+  username: gateway
+  password: mypassword
+  name: ssg
+
+## If loading a TLS Key/Pair
+# This key will become the default ssl key. Can only have one.
+# use with helm command: --set-file tls.key=/path/to/ssl.p12 --set tls.pass=keypass
+## Reference an existing secret for the Gateway Private Key, the secret needs to contain the following.
+  # SSG_SSL_KEY - decoded value needs to be base64 encoded. (cat ssl.p12 | base64 --wrap=0)
+  # SSG_SSL_KEY_PASS
+tls:
+  useSignedCertificates: false
+  # existingSecretName: ssg-tls
+# It is not recommendeded to load private keys in values.yaml, use an existingTlsSecret.
+  key:
+  pass:
 
 # Cluster Password
 clusterPassword: mypassword
@@ -456,8 +474,9 @@ service:
 
 # This enables/disables otk install or upgrade.
 # Prerequisites.
-#  1. OTK DB is installed. 
-#  2. restman is enabled. Can be disabled once the install/upgrage is complete (management.restman.enabled: true) 
+#  1. OTK DB is installed.
+#  2. restman is enabled. Can be disabled once the install/upgrage is complete (management.restman.enabled: true)
+# Note: In dual gateway installation, restart the pods after OTK install or upgrade.
 otk:
   enabled: false
   # OTK installation type - SINGLE, DMZ or INTERNAL
@@ -471,11 +490,11 @@ otk:
   # skipPostInstallationTasks: false
 
   # Specify internal gateway host and port for DMZ OTK type
-  # internalGatewayHost: 
+  # internalGatewayHost:
   # internalGatewayPort:
 
   # Specify DMZ gateway host and port for interal OTK type
-  # dmzGatewayHost: 
+  # dmzGatewayHost:
   # dmzGatewayPort:
 
   # List of comma seperated sub soluction Kits to install or upgrade.
@@ -492,7 +511,7 @@ otk:
     # OTK database type - mysql/oracle/cassandra
     type: mysql
     connectionName: OAuth
-    #existingSecretName: otkdb-secret
+    # existingSecretName: otkdb-secret
     username: root
     password: 7layer
     properties: {"maximumPoolSize":15, "minimumPoolSize":3}
@@ -507,6 +526,7 @@ otk:
     #   connectionPoints: localhost
     #   port:
     #   keyspace:
+    # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     #   driverConfig: {"localDataCenterName" : "DC1"}
 
   # Install OTK Health check bundle on gateway. Uses config map.
@@ -567,20 +587,20 @@ ingress:
   # By default clusterHostname is used, only set this if you want to use a different host
    ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
   tls:
-  - hosts: 
+  - hosts:
     - dev.ca.com
     secretName: default
   # - hosts:
   #   - dev1.ca.com
   #   secretName: default
-  
+
   rules:
-   - host: dev.ca.com
-     path: "/"
-     service:
-       port:
-         name: https
-        # number:
+  - host: dev.ca.com
+    path: "/"
+    service:
+      port:
+        name: https
+      # number:
   #  - host: dev1.ca.com
   #    path: "/"
   #    service:
@@ -622,7 +642,7 @@ existingBundle:
   #       secretProviderClass: "secret-provider-class-name"
  # - name: mysecretbundle2
 
- # This is limited to a single configmap or secret. ConfigMaps and Secrets can hold multiple scripts.
+# This is limited to a single configmap or secret. ConfigMaps and Secrets can hold multiple scripts.
 # See an example here - https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples
 # NOTE: if you set a configMap and a Secret only one of them will be applied to your API Gateway.
 existingHealthCheck:
@@ -639,7 +659,7 @@ existingHealthCheck:
     #   volumeAttributes:
     #     secretProviderClass: "vault-database"
 
-    # Certain folders on the Container Gateway are not writeable by design.
+# Certain folders on the Container Gateway are not writeable by design.
 # This configuration allows you to mount configMap/Secret keys to specific paths on the Gateway without
 # the need for a root user or a custom/derived image.
 customConfig:

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -193,7 +193,46 @@ data:
     copy "custom properties" ".properties" $CUSTOM_PROPERTIES_DIR $TARGET_CUSTOM_PROPERTIES_DIR
     copy "custom health checks" ".sh" $CUSTOM_HEALTHCHECK_SCRIPTS_DIR $TARGET_HEALTHCHECK_DIR
     run "custom shell scripts" ".sh" $CUSTOM_SHELL_SCRIPTS_DIR
-
 {{- end}}
+{{- if .Values.preStopScript.enabled }}
+  gracefulshutdown: |-
+    #!/bin/bash
+    PERIOD_SECONDS=$1
+    CHECK_INTERVAL=$2
+    EXCLUDE="${@:3}"
+    
+    PORTS=$(netstat -an | awk '/LISTEN/ { n = split($4, a, ":"); print a[n] }')
+    
+    if [ -z $PERIOD_SECONDS ]; then
+    PERIOD_SECONDS=30
+    fi
+    
+    TIMEOUT_TS=$(($(date +%s) + $PERIOD_SECONDS))
+    
+    # Remove excluded ports
+    for p in $EXCLUDE; do
+      PORTS=("${PORTS[@]/$p}")
+    done
+    
+    while [ $(date +%s) -lt $TIMEOUT_TS ]; do
+        BUSY_PORTS=0
+        for p in $PORTS; do
+            # Check open connections
+            CONNECTIONS=$(netstat -anp | grep ESTABLISHED | grep java | awk '{ print $4 }' | grep :$p | wc -l)
+            if [ $CONNECTIONS -gt 0 ]; then
+                let BUSY_PORTS++
+                echo Port $p has $CONNECTIONS connection open
+            fi
+        done
+    
+        if [ $BUSY_PORTS -eq 0 ]; then
+            echo "no open connections"
+            exit 0
+        fi
+        sleep $CHECK_INTERVAL
+    done
+    exit 0
+
+{{- end }}
     
 {{- end }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if .Values.global.schedulerName }}
       schedulerName: {{ .Values.global.schedulerName }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{.Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers: {{- toYaml .Values.initContainers | nindent 12 }}
       {{- end }}
@@ -74,8 +77,22 @@ spec:
           {{- if .Values.containerSecurityContext }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
-          {{- if .Values.installSolutionKits.enabled}}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- toYaml .Values.lifecycleHooks | nindent 12 }}
+          {{- else if .Values.installSolutionKits.enabled }}
           lifecycle:
+            {{- if .Values.preStopScript.enabled }}
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - /opt/docker/gracefulshutdown.sh
+                - {{ .Values.preStopScript.timeoutSeconds | quote }}
+                - {{ .Values.preStopScript.periodSeconds | quote }}
+                {{- range .Values.preStopScript.excludedPorts}}
+                - {{ . | quote }}
+                {{- end }}
+            {{- end }}
             postStart:
               exec:
                 command:
@@ -95,6 +112,18 @@ spec:
                     curl --user {{ $.Values.management.username }}:{{ $.Values.management.password }} -k https://127.0.0.1:{{ $.Values.installSolutionKits.restmanPort }}/restman/1.0/solutionKitManagers {{ .param }} --form "file=@/tmp/{{ .file }}"
                     {{ .postInstallCommand }}
                     {{- end }}
+          {{- else if .Values.preStopScript.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - /opt/docker/gracefulshutdown.sh
+                - {{ .Values.preStopScript.timeoutSeconds | quote }}
+                - {{ .Values.preStopScript.periodSeconds | quote }}
+                {{- range .Values.preStopScript.excludedPorts}}
+                - {{ . | quote }}
+                {{- end }}
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -173,7 +202,6 @@ spec:
            {{- end }}
 {{- end }}
 {{- end }}
-
 {{- if .Values.customConfig }}
 {{- if .Values.customConfig.enabled }}
         {{- range .Values.customConfig.mounts }}
@@ -183,8 +211,6 @@ spec:
         {{- end }}
 {{- end }}
 {{- end }}
-
-
 {{- if .Values.existingBundle.enabled }}
            {{- range .Values.existingBundle.configMaps }}
             - name: {{ .name }}
@@ -206,12 +232,18 @@ spec:
               mountPath: /opt/docker/rc.d/base/update-service-account-token.xml
               subPath: update-service-account-token.xml
 {{- end }}
-
 {{- if .Values.bootstrap }}
 {{- if .Values.bootstrap.script.enabled }}
             - name: {{ template "gateway.fullname" . }}-parse-custom-files-script
               mountPath: /opt/docker/rc.d/003-parse-custom-files.sh
               subPath: 003-parse-custom-files.sh
+{{- end }}
+{{- end }}
+{{- if .Values.preStopScript }}
+{{- if .Values.preStopScript.enabled }}
+            - name: {{ template "gateway.fullname" . }}-gracefulshutdown
+              mountPath: /opt/docker/gracefulshutdown.sh
+              subPath: gracefulshutdown.sh
 {{- end }}
 {{- end }}
 {{- if .Values.initContainers }}
@@ -441,6 +473,16 @@ spec:
             items:
             - key: 003-parse-custom-files
               path: 003-parse-custom-files.sh
+{{- end }}
+{{- end }}
+{{- if .Values.preStopScript }}
+{{- if .Values.preStopScript.enabled }}
+        - name: {{ template "gateway.fullname" . }}-gracefulshutdown
+          configMap:
+            name: {{ template "gateway.fullname" . }}-configmap
+            items:
+            - key: gracefulshutdown
+              path: gracefulshutdown.sh
 {{- end }}
 {{- end }}
 {{- if .Values.existingBundle.enabled }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -104,35 +104,24 @@ pmtagger:
   # ref:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
 
+# Override all lifecycle hooks. This will take precedence over the preStopScript section below.
+lifecycleHooks: {}
+  # postStart: {}
+  # preStop: {}
 
-# Cluster Hostname
-clusterHostname: my.localdomain
+# This preStop script checks for open connections and delays pod termination for the specified timeout seconds
+# Enabling this mounts the script to /opt/docker/gracefulshutdown.sh and adds a preStop lifecycle hook to the Gateway Deployment
+preStopScript:
+  enabled: false        # Enable/Disable
+  periodSeconds: 3      # Time between checks
+  timeoutSeconds: 60    # Timeout - must be lower than terminationGracePeriodSeconds
+  excludedPorts:
+  - 2124
+  - 8777
 
-# Database configuration
-database:
-  # DB Backed or ephemeral
-  enabled: true
-  # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
-  # Do not use this demo database in production!!!
-  create: true
-  # jdbcURL: jdbc:mysql://<host>:<port>/<database> | jdbc:mysql://<host>:<port>,<host>:<port>/<database>,...
-  # Configurable, update the mysql.auth.<settings> if you change this and would like to use the demo database server.
-  username: gateway
-  password: mypassword
-  name: ssg
-
-## If loading a TLS Key/Pair
-# This key will become the default ssl key. Can only have one.
-# use with helm command: --set-file tls.key=/path/to/ssl.p12 --set tls.pass=keypass
-## Reference an existing secret for the Gateway Private Key, the secret needs to contain the following.
-  # SSG_SSL_KEY - decoded value needs to be base64 encoded. (cat ssl.p12 | base64 --wrap=0)
-  # SSG_SSL_KEY_PASS
-tls:
-  useSignedCertificates: false
-  # existingSecretName: ssg-tls
-# It is not recommendeded to load private keys in values.yaml, use an existingTlsSecret.
-  key:
-  pass:
+## terminationGracePeriodSeconds default duration in seconds kubernetes waits for container to exit before sending kill signal.
+## Defaults to 30 if not set
+# terminationGracePeriodSeconds: 90
 
 # Configure autoscaling
 # this makes use of autoscaling/v2beta2 and autoscaling/v2 for v1.23 and later
@@ -379,6 +368,35 @@ config:
   # SSG_DATABASE_USER
   # SSG_DATABASE_PASSWORD
 
+# Cluster Hostname
+clusterHostname: my.localdomain
+
+# Database configuration
+database:
+  # DB Backed or ephemeral
+  enabled: true
+  # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
+  # Do not use this demo database in production!!!
+  create: true
+  # jdbcURL: jdbc:mysql://<host>:<port>/<database> | jdbc:mysql://<host>:<port>,<host>:<port>/<database>,...
+  # Configurable, update the mysql.auth.<settings> if you change this and would like to use the demo database server.
+  username: gateway
+  password: mypassword
+  name: ssg
+
+## If loading a TLS Key/Pair
+# This key will become the default ssl key. Can only have one.
+# use with helm command: --set-file tls.key=/path/to/ssl.p12 --set tls.pass=keypass
+## Reference an existing secret for the Gateway Private Key, the secret needs to contain the following.
+  # SSG_SSL_KEY - decoded value needs to be base64 encoded. (cat ssl.p12 | base64 --wrap=0)
+  # SSG_SSL_KEY_PASS
+tls:
+  useSignedCertificates: false
+  # existingSecretName: ssg-tls
+# It is not recommendeded to load private keys in values.yaml, use an existingTlsSecret.
+  key:
+  pass:
+
 # Cluster Password
 clusterPassword: mypassword
 
@@ -492,12 +510,11 @@ otk:
   database:
     # OTK database type - mysql/oracle/cassandra
     type: mysql
-     # connectionName: OAuth
-    # existingSecretName: otkDbSecret
+    # connectionName: OAuth
+    # existingSecretName: otkdb-secret
     username: root
     password: 7layer
     # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
-    # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}
     sql:
       # jdbcURL: jdbc:mysql://<host>:<port>/<database>
@@ -514,7 +531,7 @@ otk:
 
   # Install OTK Health check bundle on gateway. Uses config map.
   # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
-  # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otkhealthcheck.bundle
+  # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otk-healthcheck.bundle
   healthCheckBundle:
     enabled: true
     useExisting: false


### PR DESCRIPTION
**Description of the change**
Updates to Gateway Container Lifecycle.
- A new preStop script has been added for graceful termination
  - terminationGracePeriodSeconds must be greater than preStopScript.timeoutSeconds
- Container Lifecycle can be overridden for custom exec/http calls

During upgrades and other events where Gateway pods are replaced you may have APIs/Services that have long running connections open.

This functionality delays Kubernetes sending a SIGTERM to the container gateway while connections remain open. This works in conjunction with terminationGracePeriodSeconds which should always be higher than preStopScript.timeoutSeconds. If preStopScript.timeoutSeconds is exceeded, the script will exit 0 and normal pod termination will resume.

The graceful termination (preStop script) is disabled by default.

| Parameter                        | Description                               | Default                                                      |
| -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
| `lifecycleHooks`          | Custom lifecycle hooks, takes precedence over the preStopScript | `{}`  |
| `preStopScript.enabled`          | Enable the preStop script | `false`  |
| `preStopScript.periodSeconds`          | The time in seconds between checks | `3`  |
| `preStopScript.timeoutSeconds`          | Timeout - must be lower than terminationGracePeriodSeconds  | `60`  |
| `preStopScript.excludedPorts`          | Array of ports that should be excluded from the preStop script check | `[8777, 2124]`  |
| `terminationGracePeriodSeconds`          | Default duration in seconds kubernetes waits for container to exit before sending kill signal. | `see values.yaml`  |


**Benefits**
Existing connections during pod termination are respected for a configurable period of time

**Applicable issues**
DE569702


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

