### PR TITLE
[charts/portal]Changes to use existing DB secret that contains the DB password

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -210,6 +210,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `portal.defaultTenantId` | **Important!** Do not change the default tenant ID unless you have been using a different tenant ID in your previous install/deployment. There is a 15 character limit. See [DNS Configuration](#dns-configuration) for tenant ID character limitations.  | `apim` |
 | `portal.registryCredentials` | Used to create image pull secret, see prerequisites | `` |
 | `portal.useExistingPullSecret` | Configures Portal Deployment to use **global.pullSecret** as imagePullSecret | `false` |
+| `portal.useExistingDBSecret` | Configures Portal Deployment to use **global.databaseSecret** for fetching the DB password | `false` |
 | `portal.imagePullSecret.enabled` | Configures Portal Deployment to use custom registry, this option is only evaluated only when portal.registryCredentials option is not used | `false` |
 | `portal.imagePullSecret.username`          | Custom registry Username | `nil`  |
 | `portal.imagePullSecret.password`          | Custom registry Password | `nil`  |

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -172,7 +172,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `global.portalRepository` | Image Repository | `caapim/` |
 | `global.pullSecret` | Image Pull Secret name | `broadcom-apim` |
 | `global.setupDemoDatabase` | Deploys MySQL as part of this Chart | `false` |
-| `global.databaseSecret` | Database secret name. If **global.setupDemoDatabase** is true ensure **mysql.auth.existingSecret** use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password` | `database-secret` |
+| `global.databaseSecret` | Database secret name. If **global.setupDemoDatabase** is true, ensure **mysql.auth.existingSecret** uses the same secret that contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password` | `database-secret` |
 | `global.useExistingDatabaseSecret` | Configures Portal Deployment to use **global.databaseSecret** for fetching the DB password | `false` |
 | `global.databaseUsername` | Database username | `admin` |
 | `global.demoDatabaseRootPassword` | Demo Database root password | `7layer`|

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -172,7 +172,8 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `global.portalRepository` | Image Repository | `caapim/` |
 | `global.pullSecret` | Image Pull Secret name | `broadcom-apim` |
 | `global.setupDemoDatabase` | Deploys MySQL as part of this Chart | `false` |
-| `global.databaseSecret` | Database secret name | `database-secret` |
+| `global.databaseSecret` | Database secret name. If **global.setupDemoDatabase** is true ensure **mysql.auth.existingSecret** use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password` | `database-secret` |
+| `global.useExistingDatabaseSecret` | Configures Portal Deployment to use **global.databaseSecret** for fetching the DB password | `false` |
 | `global.databaseUsername` | Database username | `admin` |
 | `global.demoDatabaseRootPassword` | Demo Database root password | `7layer`|
 | `global.demoDatabaseReplicationPassword` | Demo Database replication password | `7layer`|
@@ -210,7 +211,6 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `portal.defaultTenantId` | **Important!** Do not change the default tenant ID unless you have been using a different tenant ID in your previous install/deployment. There is a 15 character limit. See [DNS Configuration](#dns-configuration) for tenant ID character limitations.  | `apim` |
 | `portal.registryCredentials` | Used to create image pull secret, see prerequisites | `` |
 | `portal.useExistingPullSecret` | Configures Portal Deployment to use **global.pullSecret** as imagePullSecret | `false` |
-| `portal.useExistingDBSecret` | Configures Portal Deployment to use **global.databaseSecret** for fetching the DB password | `false` |
 | `portal.imagePullSecret.enabled` | Configures Portal Deployment to use custom registry, this option is only evaluated only when portal.registryCredentials option is not used | `false` |
 | `portal.imagePullSecret.username`          | Custom registry Username | `nil`  |
 | `portal.imagePullSecret.password`          | Custom registry Password | `nil`  |

--- a/charts/portal/templates/common/database-secret.yaml
+++ b/charts/portal/templates/common/database-secret.yaml
@@ -1,4 +1,4 @@
-{{ if not (.Values.portal.useExistingDBSecret) }}
+{{ if not (.Values.global.useExistingDBSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/portal/templates/common/database-secret.yaml
+++ b/charts/portal/templates/common/database-secret.yaml
@@ -1,4 +1,4 @@
-{{ if not (.Values.global.useExistingDBSecret) }}
+{{ if not (.Values.global.useExistingDatabaseSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/portal/templates/common/database-secret.yaml
+++ b/charts/portal/templates/common/database-secret.yaml
@@ -1,3 +1,4 @@
+{{ if not (.Values.portal.useExistingDBSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,4 +30,5 @@ data:
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
 {{ end }}
 
+{{ end }}
 {{ end }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -53,6 +53,8 @@ portal:
   ssoDebug: false
   hostnameWhitelist:
   defaultTenantId: apim
+  # Set this to true if there is already an existing pull secret that has DB password as value and key name 'mysql-password' available.
+  useExistingDBSecret: false
   #Configuration to use custom registries to pull the container images with appropriate credentials.
   #This refers to the dockerconfigjson that contains the information about the registry and its creds.
   registryCredentials:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -10,7 +10,7 @@ global:
   databaseType: mysql
   databaseSecret: database-secret
   # Set this to true if there is already an existing pull secret that contains the key 'mysql-password'.
-  # If setupDemoDatabase is true ensure mysql.auth.existingSecret use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password`
+  # If **global.setupDemoDatabase** is true, ensure **mysql.auth.existingSecret** uses the same secret that contain the keys `mysql-root-password`, `mysql-replication-password`.
   useExistingDatabaseSecret: false
   databaseUsername: portal
 # databasePassword: 7layer

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -9,6 +9,9 @@ global:
   # By default a user called admin will be created and given admin rights
   databaseType: mysql
   databaseSecret: database-secret
+  # Set this to true if there is already an existing pull secret that contains the key 'mysql-password'.
+  # If setupDemoDatabase is true ensure mysql.auth.existingSecret use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password`
+  useExistingDatabaseSecret: false
   databaseUsername: portal
 # databasePassword: 7layer
 # demoDatabaseRootPassword: 7layer
@@ -53,8 +56,6 @@ portal:
   ssoDebug: false
   hostnameWhitelist:
   defaultTenantId: apim
-  # Set this to true if there is already an existing pull secret that has DB password as value and key name 'mysql-password' available.
-  useExistingDBSecret: false
   #Configuration to use custom registries to pull the container images with appropriate credentials.
   #This refers to the dockerconfigjson that contains the information about the registry and its creds.
   registryCredentials:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -10,7 +10,7 @@ global:
   databaseType: mysql
   databaseSecret: database-secret
   # Set this to true if there is already an existing pull secret that contains the key 'mysql-password'.
-  # If setupDemoDatabase is true ensure mysql.auth.existingSecret use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password`
+  # If **global.setupDemoDatabase** is true, ensure **mysql.auth.existingSecret** uses the same secret that contain the keys `mysql-root-password`, `mysql-replication-password`.
   useExistingDatabaseSecret: false
   databaseUsername: portal
 # databasePassword: 7layer

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -9,6 +9,9 @@ global:
   # By default a user called admin will be created and given admin rights
   databaseType: mysql
   databaseSecret: database-secret
+  # Set this to true if there is already an existing pull secret that contains the key 'mysql-password'.
+  # If setupDemoDatabase is true ensure mysql.auth.existingSecret use the same secret is used and contain the keys `mysql-root-password`, `mysql-replication-password` along with `mysql-password`
+  useExistingDatabaseSecret: false
   databaseUsername: portal
 # databasePassword: 7layer
 # demoDatabaseRootPassword: 7layer
@@ -55,8 +58,6 @@ portal:
   ssoDebug: false
   hostnameWhitelist:
   defaultTenantId: apim
-  # Set this to true if there is already an existing pull secret that has DB password as value and key name 'mysql-password' available.
-  useExistingDBSecret: false
   # Configuration to use custom registries to pull the container images with appropriate credentials.
   # This refers to the dockerconfigjson that contains the information about the registry and its creds.
   registryCredentials:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -55,6 +55,8 @@ portal:
   ssoDebug: false
   hostnameWhitelist:
   defaultTenantId: apim
+  # Set this to true if there is already an existing pull secret that has DB password as value and key name 'mysql-password' available.
+  useExistingDBSecret: false
   # Configuration to use custom registries to pull the container images with appropriate credentials.
   # This refers to the dockerconfigjson that contains the information about the registry and its creds.
   registryCredentials:


### PR DESCRIPTION
**Description of the change**

Changes to use existing DB secret that contains the DB password.

**Benefits**

Enables customers not to expose the DB password from values override files. 

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

