### PR TITLE
[charts/gateway] Update otk-install-job.yaml with ContainerSecurityContext from gateway values chart

### DIFF
--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -33,6 +33,9 @@ spec:
         - name: otk-install
           image: {{.Values.image.registry}}/{{.Values.otk.job.image.repository}}:{{.Values.otk.job.image.tag}}
           imagePullPolicy: {{ .Values.otk.job.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ template "otk.dbSecretName" . }}


### PR DESCRIPTION
**Description of the change**

Currently there is a ContainerSecurityContext option in the main values file. It is expected that this is applied to all containers deployed with the gateway helm chart. However it is only applied to the deployment template and the pm-tagger-deployment template (which also seems bugged). Before I would patch this with using kustomize as a post renderer but with this particular job that is not possible since it's a post-install,post-upgrade helm job.

**Benefits**

You will be able to set the containerSecurityContext to meet your kubernetes cluster's security requirements and run the job. 

**Drawbacks**

No drawbacks since it is optional.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
Currently I cannot use the otk-install job since our cluster has Polaris running which blocks any containers without a specific SecurityContext defined.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

