### PR TITLE
charts/gateway add internal/external traffic policy config

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.11
+version: 3.0.12
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,12 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.12 General Updates
+Traffic Policies for Gateway Services are now configurable. The Kubernetes default for these options is `Cluster` if left unset.
+- [Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy)
+- [External Traffic Policy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)
+
+
 ## 3.0.11 General Updates
 Updates to Gateway Container Lifecycle.
 - [A new preStop script has been added for graceful termination](#graceful-termination)
@@ -321,6 +327,8 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `service.loadbalancer`    | Additional Loadbalancer Configuration               | `see https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service` |
 | `service.ports`    | List of http external port mappings               | https: 8443 -> 8443, management: 9443->9443 |
 | `service.annotations`    | Additional annotations to add to the service               | {} |
+| `service.internalTrafficPolicy`    | [Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy)               | `Cluster` |
+| `service.externalTrafficPolicy`    | [External Traffic Policy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)               | `Cluster` |
 | `ingress.enabled`    | Enable/Disable an ingress record being created               | `false` |
 | `ingress.annotations`    | Additional ingress annotations               | `{}` |
 | `ingress.hostname`    | Sets Ingress Hostname  | `nil` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -438,6 +438,11 @@ management:
     #   clientIP:
     #     timeoutSeconds: 10800
 
+    # Internal Traffic Policy - https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy
+    # internalTrafficPolicy: Cluster
+    # External Traffic Policy - https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    # externalTrafficPolicy: Cluster
+
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
   type: ClusterIP
@@ -471,6 +476,11 @@ service:
   # sessionAffinityConfig:
   #   clientIP:
   #     timeoutSeconds: 10800
+
+  # Internal Traffic Policy - https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy
+  # internalTrafficPolicy: Cluster
+  # External Traffic Policy - https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  # externalTrafficPolicy: Cluster
 
 # This enables/disables otk install or upgrade.
 # Prerequisites.

--- a/charts/gateway/templates/management-service.yaml
+++ b/charts/gateway/templates/management-service.yaml
@@ -45,4 +45,10 @@ spec:
   {{- if .Values.management.service.sessionAffinityConfig }}
   sessionAffinityConfig: {{- toYaml .Values.management.service.sessionAffinityConfig | nindent 4 }}
   {{- end }}
+  {{- if .Values.management.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.management.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.management.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.management.service.internalTrafficPolicy }}
+  {{- end }}
   {{ end }}

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -43,3 +43,9 @@ spec:
   {{- if .Values.service.sessionAffinityConfig }}
   sessionAffinityConfig: {{- toYaml .Values.service.sessionAffinityConfig | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -438,6 +438,11 @@ management:
     #   clientIP:
     #     timeoutSeconds: 10800
 
+    # Internal Traffic Policy - https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy
+    # internalTrafficPolicy: Cluster
+    # External Traffic Policy - https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    # externalTrafficPolicy: Cluster
+
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
   type: LoadBalancer
@@ -471,6 +476,11 @@ service:
   # sessionAffinityConfig:
   #   clientIP:
   #     timeoutSeconds: 10800
+
+  # Internal Traffic Policy - https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy
+  # internalTrafficPolicy: Cluster
+  # External Traffic Policy - https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  # externalTrafficPolicy: Cluster
 
 # This enables/disables otk install or upgrade.
 # Prerequisites.


### PR DESCRIPTION
**Description of the change**
## 3.0.12 General Updates
Traffic Policies for Gateway Services are now configurable. The Kubernetes default for these options is `Cluster` if left unset.
- [Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy)
- [External Traffic Policy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)

**Benefits**
Internal and External Traffic Policies are configurable

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

