### PR TITLE
charts/gateway updated pod label/annotation templating, added securit…

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.12
+version: 3.0.13
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,10 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.13 General Updates
+- The OTK Install job now uses podSecurity and containerSecurity contexts if set.
+- Updated how pod labels and annotations are templated in deployment.yaml  
+
 ## 3.0.12 General Updates
 Traffic Policies for Gateway Services are now configurable. The Kubernetes default for these options is `Cluster` if left unset.
 - [Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy)

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -28,14 +28,11 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
-    {{- range $key, $val := .Values.podLabels }}
-        {{ $key }}: "{{ $val }}"
+    {{- if  .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
     {{- end }}
     {{- if  .Values.podAnnotations }}
-      annotations:
-    {{- range $key, $val := .Values.podAnnotations }}
-        {{ $key }}: "{{ $val }}"
-    {{- end }}
+      annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
     {{- end }}
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -29,10 +29,16 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
         - name: otk-install
           image: {{.Values.image.registry}}/{{.Values.otk.job.image.repository}}:{{.Values.otk.job.image.tag}}
           imagePullPolicy: {{ .Values.otk.job.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ template "otk.dbSecretName" . }}


### PR DESCRIPTION
**Description of the change**
## 3.0.13 General Updates
- The OTK Install job now uses podSecurity and containerSecurity contexts if set.
- Updated how pod labels and annotations are templated in deployment.yaml  

**Benefits**
- podLabels and annotations are more flexible
- securityContext can be set for the otk-install job

**Applicable issues**
Covers this [PR](https://github.com/CAAPIM/apim-charts/pull/232) from SebastiaanKveek

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

