### PR TITLE
Add connection properties for sql connection

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -475,7 +475,8 @@ database:
 | `otk.database.properties`         | OTK database additional properties  | `{}` |
 | `otk.database.sql.type`           | OTK database type (mysql/oracle/cassandra) | `mysql` | 
 | `otk.database.sql.jdbcURL`        | OTK database sql jdbc URL (oracle/mysql) | 
-| `otk.database.sql.jdbcDriverClass`| OTK database sql driver class name (oracle/mysql) | 
+| `otk.database.sql.jdbcDriverClass`| OTK database sql driver class name (oracle/mysql) |
+| `otk.database.sql.connectionProperties`| OTK database mysql connection properties (mysql) | `{}`
 | `otk.database.sql.databaseName`   | OTK database Oracle database name |
 | `otk.database.readOnlyConnection.enabled`            | Enable/Disable OTK read only database connection | `false` | 
 | `otk.database.readOnlyConnection.connectionName`     | OTK read only database connection name | `OAuth_ReadOnly` | 
@@ -484,7 +485,8 @@ database:
 | `otk.database.readOnlyConnection.password`           | OTK read only database password |
 | `otk.database.readOnlyConnection.properties`         | OTK read only database additional properties  | `{}` | 
 | `otk.database.readOnlyConnection.jdbcURL`            | OTK read only database sql jdbc URL (oracle/mysql) | 
-| `otk.database.readOnlyConnection.jdbcDriverClass`    | OTK read only database sql driver class name (oracle/mysql) | 
+| `otk.database.readOnlyConnection.jdbcDriverClass`    | OTK read only database sql driver class name (oracle/mysql) |
+| `otk.database.readOnlyConnection.connectionProperties`| OTK read only database mysql connection properties (mysql) | `{}`
 | `otk.database.readOnlyConnection.databaseName`       | OTK read only Oracle database name |
 | `otk.database.cassandra.connectionPoints`  | OTK database cassandra connection points (comma seperated)  | 
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -546,6 +546,7 @@ otk:
       # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       jdbcURL:
       jdbcDriverClass: com.mysql.jdbc.Driver
+      # connectionProperties: {"c3p0.maxPoolSize":15,"c3p0.maxConnectionAge":0,"c3p0.maxIdleTime":0}
       # Oracle database name
       # databaseName:
     # cassandra:
@@ -563,6 +564,7 @@ otk:
       # username: root
       # password: 7layer
       # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
+      # connectionProperties: {"c3p0.maxPoolSize":15,"c3p0.maxConnectionAge":0,"c3p0.maxIdleTime":0}
       # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       # jdbcDriverClass: com.mysql.jdbc.Driver
       # Oracle database name

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -527,10 +527,15 @@ otk:
     connectionName: OAuth
     dbUpgrade: true
     useDemoDb: true
-  
+    
+    # username: root
+    # password: 7layer
+    
     # ddlUsername:
     # ddlPassword:
+    
     # existingSecretName: otkDbSecret
+    
     # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -39,7 +39,7 @@ spec:
           env:
            - name: OTK_TYPE
              value: {{ template "otk-install-type" .}}
-{{- if and (ne .Values.otk.database.useDemoDb) (.Values.otk.database.changeLogSync)}}
+{{- if and (not .Values.otk.database.useDemoDb) (.Values.otk.database.changeLogSync)}}
            - name: OTK_LIQUIBASE_OPERATION
              value: "changelogSync"
 {{ end }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -84,6 +84,8 @@ spec:
              value: {{ default .Values.otk.database.sql.jdbcDriverClass .Values.otk.database.readOnlyConnection.jdbcDriverClass | quote }}
            - name: OTK_RO_DATABASE_PROPERTIES
              value: {{ default "na" .Values.otk.database.readOnlyConnection.properties | toJson | b64enc | quote }}
+           - name: OTK_RO_DATABASE_CONN_PROPERTIES
+             value: {{ default "na" .Values.otk.database.readOnlyConnection.connectionProperties | toJson | b64enc | quote }}
 {{ end }}
 {{ end }}
 
@@ -94,9 +96,11 @@ spec:
            - name: OTK_RO_DATABASE_NAME
              value: {{ default .Values.otk.database.sql.databaseName .Values.otk.database.readOnlyConnection.databaseName | quote }}           
 {{ end }}             
-{{ end }}           
+{{ end }}
            - name: OTK_DATABASE_PROPERTIES
              value: {{ default "na" .Values.otk.database.properties | toJson | b64enc | quote }}
+           - name: OTK_DATABASE_CONN_PROPERTIES
+             value: {{ default "na" .Values.otk.database.sql.connectionProperties | toJson | b64enc | quote }}
 {{ end }}
            - name: OTK_CREATE_RO_DATABASE_CONN
 {{ if and (.Values.otk.database.useDemoDb) (eq .Values.otk.database.type "mysql")}}
@@ -130,7 +134,6 @@ spec:
              value: {{default false .Values.otk.enablePortalIngeration | quote }}
            - name: OTK_SKIP_POST_INSTALLATION_TASKS
              value: {{default false .Values.otk.skipPostInstallationTasks | quote }}
-
 {{- if .Values.imagePullSecret.enabled }}
       imagePullSecrets:
         - name: {{ template "otk.imagePullSecret" . }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -546,6 +546,7 @@ otk:
       # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       jdbcURL:
       jdbcDriverClass: com.mysql.jdbc.Driver
+      # connectionProperties: {"c3p0.maxPoolSize":15,"c3p0.maxConnectionAge":0,"c3p0.maxIdleTime":0}
       # Oracle database name
       # databaseName:
     # cassandra:
@@ -563,6 +564,7 @@ otk:
       # username: root
       # password: 7layer
       # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
+      # connectionProperties: {"c3p0.maxPoolSize":15,"c3p0.maxConnectionAge":0,"c3p0.maxIdleTime":0}
       # jdbcURL: jdbc:mysql://<host>:<port>/<database>
       # jdbcDriverClass: com.mysql.jdbc.Driver
       # Oracle database name

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -485,7 +485,7 @@ service:
 # This enables/disables otk install or upgrade.
 # Prerequisites.
 #  1. OTK DB is installed.
-#  2. restman is enabled. Can be disabled once the install/upgrage is complete (management.restman.enabled: true)
+#  2. Restman is enabled for DB backed Gateway. Can be disabled once the install/upgrage is complete (management.restman.enabled: true)
 #  Note: In dual gateway installation, restart the pods after OTK install or upgrade.
 otk:
   enabled: false
@@ -528,9 +528,14 @@ otk:
     dbUpgrade: true
     useDemoDb: true
   
+    # username: root
+    # password: 7layer
+
     # ddlUsername:
     # ddlPassword:
+
     # existingSecretName: otkDbSecret
+    
     # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
     # For Cassandra driverConfig is supported from GW 11.0. Either otk.database.cassandra.driverConfig or otk.database.properties should be provided
     # properties: {"localDataCenterName" : "DC1"}


### PR DESCRIPTION
**Description of the change**
OTK mysql connection can now be configured with connection properties.

**Benefits**
Customize connection properties for mysql.

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

