### PR TITLE
charts/gateway added otk podLabels and podAnnotations

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.13
+version: 3.0.14
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -39,8 +39,8 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
 
 ## 3.0.14 General Updates
 - Added pod labels and annotations to the otk-install job.
-  - otk.podLabels
-  - otk.podAnnotations
+  - otk.job.podLabels
+  - otk.job.podAnnotations
 
 ## 3.0.13 General Updates
 - The OTK Install job now uses podSecurity and containerSecurity contexts if set.
@@ -469,8 +469,8 @@ database:
 | `otk.job.image.labels`            | Job lables | {}
 | `otk.job.image.nodeSelector`      | Job Node selector | {}
 | `otk.job.image.tolerations`       | Job tolerations | []
-| `otk.podLabels`                   | OTK Job podLabels | {}
-| `otk.podAnnotations`              | OTK Job podAnnotations | {}
+| `otk.job.podLabels`                   | OTK Job podLabels | {}
+| `otk.job.podAnnotations`              | OTK Job podAnnotations | {}
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,11 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.14 General Updates
+- Added pod labels and annotations to the otk-install job.
+  - otk.podLabels
+  - otk.podAnnotations
+
 ## 3.0.13 General Updates
 - The OTK Install job now uses podSecurity and containerSecurity contexts if set.
 - Updated how pod labels and annotations are templated in deployment.yaml  
@@ -464,6 +469,8 @@ database:
 | `otk.job.image.labels`            | Job lables | {}
 | `otk.job.image.nodeSelector`      | Job Node selector | {}
 | `otk.job.image.tolerations`       | Job tolerations | []
+| `otk.podLabels`                   | OTK Job podLabels | {}
+| `otk.podAnnotations`              | OTK Job podAnnotations | {}
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -509,6 +509,15 @@ otk:
 
   # List of comma seperated sub soluction Kits to install or upgrade.
   # subSolutionKitNames:
+
+  ## Pod Labels for the OTK install Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # Pod Annotations apply to the OTK install Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
   job:
     image:
       repository: caapim/otk-install

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -510,14 +510,6 @@ otk:
   # List of comma seperated sub soluction Kits to install or upgrade.
   # subSolutionKitNames:
 
-  ## Pod Labels for the OTK install Pod
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  podLabels: {}
-
-  # Pod Annotations apply to the OTK install Pod
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  podAnnotations: {}
-
   job:
     image:
       repository: caapim/otk-install
@@ -526,6 +518,13 @@ otk:
     labels: {}
     # nodeSelector: {}
     # tolerations: []
+    ## Pod Labels for the OTK install Pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    podLabels: {}
+
+    # Pod Annotations apply to the OTK install Pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    podAnnotations: {}
   database:
     # OTK database type - mysql/oracle/cassandra
     type: mysql

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -31,11 +31,11 @@ spec:
       labels:
         app: {{ template "gateway.fullname" . }}
         release: {{ .Release.Name }}
-    {{- if  .Values.otk.podLabels }}
-        {{- toYaml .Values.otk.podLabels | nindent 8 }}
+    {{- if  .Values.otk.job.podLabels }}
+        {{- toYaml .Values.otk.job.podLabels | nindent 8 }}
     {{- end }}
-    {{- if  .Values.otk.podAnnotations }}
-      annotations: {{- toYaml .Values.otk.podAnnotations | nindent 8 }}
+    {{- if  .Values.otk.job.podAnnotations }}
+      annotations: {{- toYaml .Values.otk.job.podAnnotations | nindent 8 }}
     {{- end }}
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -27,6 +27,16 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app: {{ template "gateway.fullname" . }}
+        release: {{ .Release.Name }}
+    {{- if  .Values.otk.podLabels }}
+        {{- toYaml .Values.otk.podLabels | nindent 8 }}
+    {{- end }}
+    {{- if  .Values.otk.podAnnotations }}
+      annotations: {{- toYaml .Values.otk.podAnnotations | nindent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: {{ include "gateway.serviceAccountName" . }}
       {{- if .Values.podSecurityContext }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -509,6 +509,15 @@ otk:
 
   # List of comma seperated sub soluction Kits to install or upgrade.
   # subSolutionKitNames:
+
+  ## Pod Labels for the OTK install Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  # Pod Annotations apply to the OTK install Pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
   job:
     image:
       repository: caapim/otk-install

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -510,14 +510,6 @@ otk:
   # List of comma seperated sub soluction Kits to install or upgrade.
   # subSolutionKitNames:
 
-  ## Pod Labels for the OTK install Pod
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  podLabels: {}
-
-  # Pod Annotations apply to the OTK install Pod
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  podAnnotations: {}
-
   job:
     image:
       repository: caapim/otk-install
@@ -526,6 +518,13 @@ otk:
     labels: {}
     # nodeSelector: {}
     # tolerations: []
+    ## Pod Labels for the OTK install Pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    podLabels: {}
+
+    # Pod Annotations apply to the OTK install Pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    podAnnotations: {}
   database:
     # OTK database type - mysql/oracle/cassandra
     type: mysql


### PR DESCRIPTION
**Description of the change**
## 3.0.14 General Updates
- Added pod labels and annotations to the otk-install job.
  - otk.podLabels
  - otk.podAnnotations

**Benefits**
Pod Labels and Annotations are configurable for the OTK install job


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

