### PR TITLE
[charts/gateway] pm-tagger pdb

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.1.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.5
+version: 3.0.6
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/templates/pm-tagger-pdb.yaml
+++ b/charts/gateway/templates/pm-tagger-pdb.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.pdb.create }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: {{ template "gateway.fullname" . }}-pm-tagger-pdb
+  name: {{ template "gateway.fullname" . }}-pm-tagger-pdb
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "gateway.fullname" . }}-pm-tagger
+{{ end }}


### PR DESCRIPTION
**Description of the change**

Permits pm-tagger to utilize PDBs. I am not actually familiar with what pm-tagger is or does, but noticed it has running pods and therefore took a guess that it might be worthwhile to give it a PDB, as well.

**Benefits**

Other gateway components (pm-tagger) will utilize PDBs.

**Drawbacks**

This shares the pdb value with the gateway pod itself. Happy to split these up if needed

**Applicable issues**

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

