### PR TITLE
Added restartOnConfigChange flag to trigger Gateway Deployment if configMap changes during helm upgrade

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 2.0.3
+version: 2.0.2
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:
   - name: Gazza7205

--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: gateway-otk
 version: 2.0.2
+appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:
   - name: Gazza7205

--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 2.0.2
-appVersion: "10.1.00"
+version: 2.0.3
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:
   - name: Gazza7205

--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 2.0.2
+version: 2.0.3
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:
   - name: Gazza7205

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.14
+version: 3.0.15
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.15
+version: 3.0.16
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,17 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.16 General Updates
+- Added annotation to the Gateway , to allow automatic roll deployments if any value change like SSG_DATABASE_JDBC_URL in Gateway configMap
+
+- restartOnConfigChange flag when enabled will add checksum/config annotation to Gateway configMap
+```
+# restartOnConfigChange flag is disabled by default
+restartOnConfigChange:
+enabled: false
+
+```
+
 ## 3.0.15 General Updates
 - Updated [bootstrap script](#bootstrap-script)
   - 'find' replaced with 'du'
@@ -64,14 +75,6 @@ Updates to Gateway Container Lifecycle.
 
 ## 3.0.10 General Updates
 Custom labels and annotations have been extended to all objects the Gateway Chart deploys. Pod Labels and annotations have been added to the Gateway and PM-Tagger deployments.
-
-- restartOnConfigChange flag will allow automatic roll deployments on any configMap chnage
-```
-# restartOnConfigChange flag is disabled by default
-restartOnConfigChange:
-enabled: false
-
-```
 
 - Additional Labels/Annotations apply to everything in this Chart's templates
 ```
@@ -124,7 +127,7 @@ The bootstrap script has been updated to reflect changes to the Container Gatewa
 The PM Tagger image default version tag been updated to 1.0.1.
 
 ## 3.0.6 General Updates
-The default image tag in values.yaml and production-values.yaml for OTK updated to **4.6.1**. Support for liveness and readiness probes using OTK health check service. 
+The default image tag in values.yaml and production-values.yaml for OTK updated to **4.6.1**. Support for liveness and readiness probes using OTK health check service.
 
 ## 3.0.5 General Updates
 The default image tag in values.yaml and production-values.yaml, and the appVersion in Chart.yaml have been updated to **11.0.00**.
@@ -155,7 +158,7 @@ The following configuration options have been added
 - SubCharts now show image repository and tags
 
 ### Upgrading to Chart v3.0.0
-Please see the 3.0.0 updates, this release brings significant updates and ***breaking changes*** if you are using an external Hazelcast 3.x server. Services and Ingress configuration have also changed. Read the 3.0.0 Updates below and check out the [additional guides](#additional-guides) for more info. 
+Please see the 3.0.0 updates, this release brings significant updates and ***breaking changes*** if you are using an external Hazelcast 3.x server. Services and Ingress configuration have also changed. Read the 3.0.0 Updates below and check out the [additional guides](#additional-guides) for more info.
 
 ## 3.0.0 Updates to Hazelcast
 ***Hazelcast 4.x/5.x servers are now supported*** this represents a breaking change if you have configured an external Hazelcast 3.x server.
@@ -206,7 +209,7 @@ Ingress configuration has been updated to include multiple hosts, please see [In
 
 ## 2.0.4 General Updates
 - Added support for sidecars and initContainers
-  - volumeMounts are automatically configured with emptyDir 
+  - volumeMounts are automatically configured with emptyDir
 - Updated default values update to reflect empty objects/arrays for optional fields.
 - Load the Gateway Deployment's ServiceAccountToken as a stored password for querying the Kubernetes API.
   - management.kubernetes.loadServiceAccountToken
@@ -387,7 +390,7 @@ There are two types of port configuration available in the Gateway Helm Chart th
 ### Container/Service Level Ports
 
 ### Default Gateway Service
-Sample entry that exposes 8443 which is one of the default TLS port on the API Gateway using service type LoadBalancer. 
+Sample entry that exposes 8443 which is one of the default TLS port on the API Gateway using service type LoadBalancer.
 ```
 service:
   type: LoadBalancer
@@ -471,7 +474,7 @@ database:
 | `otk.forceInstallOrUpgrade`       | Force install or upgrade by uninstalling existing otk soluction kit and install. | false
 | `otk.enablePortalIngeration`      | Not applicable for DMZ and INTERNAL OTK types | `false`
 | `otk.skipPostInstallationTasks`   | Skip post installation tasks for OTK type INTERNAL and DMZ <br/>Intrenal Gateway: <br/> - #OTK Client Context Variables <br/> - #OTK id_token configuration <br/> - Import SSL Certificate of DMZ gateway <br/>DMZ Gareway: <br/> - #OTK OVP Configuration<br/> - #OTK Storage Configuration<br/> - Import SSL Certificate of Internal gateway   | `false`
-| `otk.internalGatewayHost`         | Internal gateway host for OTK type DMZ| 
+| `otk.internalGatewayHost`         | Internal gateway host for OTK type DMZ|
 | `otk.internalGatewayPort`         | Internal gateway post for OTK type DMZ|
 | `otk.dmzGatewayHost`              | DMZ gateway host for OTK type INTERNAL|
 | `otk.dmzGatewayPort`              | DMZ gateway port for OTK type INTERNAL|
@@ -487,14 +490,14 @@ database:
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |
-| `otk.database.username`           | OTK database user name | 
+| `otk.database.username`           | OTK database user name |
 | `otk.database.password`           | OTK database password |
 | `otk.database.properties`         | OTK database additional properties  | `{}`
 | `otk.database.sql.type`           | OTK database type (mysql/oracle/cassandra) | `mysql`
-| `otk.database.sql.jdbcURL`        | OTK database sql jdbc URL (oracle/mysql) | 
-| `otk.database.sql.jdbcDriverClass`| OTK database sql driver class name (oracle/mysql) | 
-| `otk.database.sql.databaseName`   | OTK database Oracle database name | 
-| `otk.database.cassandra.connectionPoints`  | OTK database cassandra connection points (comma seperated)  | 
+| `otk.database.sql.jdbcURL`        | OTK database sql jdbc URL (oracle/mysql) |
+| `otk.database.sql.jdbcDriverClass`| OTK database sql driver class name (oracle/mysql) |
+| `otk.database.sql.databaseName`   | OTK database Oracle database name |
+| `otk.database.cassandra.connectionPoints`  | OTK database cassandra connection points (comma seperated)  |
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
 | `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
@@ -536,7 +539,7 @@ config:
     ports:
       - name: Default HTTPS (8443)
         port: 8443
-      
+
         enabled: true
         protocol: HTTPS
         managementFeatures:
@@ -638,13 +641,13 @@ ingress:
   # By default clusterHostname is used, only set this if you want to use a different host
    ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
   tls:
-  - hosts: 
+  - hosts:
     - dev.ca.com
     secretName: tls-secret-1
 #  - hosts:
 #    - dev1.ca.com
 #    secretName: tls-secret-2
-  
+
   rules:
    - host: dev.ca.com
      path: "/"

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -61,6 +61,14 @@ Updates to Gateway Container Lifecycle.
 ## 3.0.10 General Updates
 Custom labels and annotations have been extended to all objects the Gateway Chart deploys. Pod Labels and annotations have been added to the Gateway and PM-Tagger deployments.
 
+- restartOnConfigChange flag will allow automatic roll deployments on any configMap chnage
+```
+# restartOnConfigChange flag is disabled by default
+restartOnConfigChange:
+enabled: false
+
+```
+
 - Additional Labels/Annotations apply to everything in this Chart's templates
 ```
 # Additional Annotations apply to all deployed objects
@@ -69,6 +77,7 @@ additionalAnnotations: {}
 # Additional Labels apply to all deployed objects
 additionalLabels: {}
 ```
+
 
 - Pod Labels/Annotations at the base level apply to the Gateway Pod
 ```

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -53,6 +53,10 @@ serviceAccount:
 rbac:
   create: true
 
+# If restartOnConfigChange is enabled , it will restart Deployment on ConfigMap change
+restartOnConfigChange:
+  enabled: false
+
 # Number of Gateways to deploy
 replicas: 1
 # Update strategy

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -53,7 +53,7 @@ serviceAccount:
 rbac:
   create: true
 
-# If restartOnConfigChange is enabled , it will restart Deployment on ConfigMap change
+# If restartOnConfigChange flag is enabled, it will add checksum/config annotation to Gateway configMap
 restartOnConfigChange:
   enabled: false
 

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -54,8 +54,8 @@ rbac:
   create: true
 
 # If restartOnConfigChange flag is enabled, it will add checksum/config annotation to Gateway configMap
-restartOnConfigChange:
-  enabled: false
+# restartOnConfigChange:
+  # enabled: false
 
 # Number of Gateways to deploy
 replicas: 1

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -11,16 +11,15 @@ metadata:
     {{ $key }}: "{{ $val }}"
     {{- end }}
   annotations:
-  {{- if .Values.restartOnConfigChange.enabled  }}
+  {{- if .Values.restartOnConfigChange }}
+     {{- if .Values.restartOnConfigChange.enabled }}
      checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
+     {{- end }}
   {{- end }}
   {{- if  .Values.additionalAnnotations }}
   {{- range $key, $val := .Values.additionalAnnotations }}
       {{ $key }}: "{{ $val }}"
   {{- end }}
-  {{- end }}
-  {{- if .Values.restartOnConfigChange.enabled  }}
-     checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
   {{- end }}
 spec:
   selector:

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -10,15 +10,18 @@ metadata:
     {{- range $key, $val := .Values.additionalLabels }}
     {{ $key }}: "{{ $val }}"
     {{- end }}
-  {{- if  .Values.additionalAnnotations }}
   annotations:
-{{- range $key, $val := .Values.additionalAnnotations }}
-    {{ $key }}: "{{ $val }}"
-{{ if  and (eq $key "restartOnConfigChange") (eq $val true)  }}
-    checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
-{{- end }}
-{{- end }}
-{{- end }}
+  {{- if .Values.restartOnConfigChange.enabled  }}
+     checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
+  {{- end }}
+  {{- if  .Values.additionalAnnotations }}
+  {{- range $key, $val := .Values.additionalAnnotations }}
+      {{ $key }}: "{{ $val }}"
+  {{- end }}
+  {{- end }}
+  {{- if .Values.restartOnConfigChange.enabled  }}
+     checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
   annotations:
 {{- range $key, $val := .Values.additionalAnnotations }}
     {{ $key }}: "{{ $val }}"
+{{ if  and (eq $key "restartOnConfigChange") (eq $val true)  }}
+    checksum/config: {{ include ( print  $.Template.BasePath "/configmap.yaml" ) $ | sha256sum }}
+{{- end }}
 {{- end }}
 {{- end }}
 spec:
@@ -126,13 +129,13 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           ports:
             {{- range .Values.service.ports }}
-            - name: {{ .name }} 
+            - name: {{ .name }}
               containerPort: {{ .internal }}
               protocol: {{ .protocol }}
             {{- end }}
             {{ if .Values.management.service.enabled}}
             {{- range .Values.management.service.ports }}
-            - name: {{ .name }} 
+            - name: {{ .name }}
               containerPort: {{ .internal }}
               protocol: {{ .protocol }}
             {{- end }}
@@ -299,7 +302,7 @@ spec:
               {{- range.Values.livenessProbe.httpHeaders }}
               - name: {{ .name }}
                 value: {{ .value }}
-              {{- end }}     
+              {{- end }}
 {{- else }}
             exec:
               command:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -53,9 +53,9 @@ serviceAccount:
 rbac:
   create: true
 
-# If restartOnConfigChange is enabled , it will restart Deployment on ConfigMap change
-restartOnConfigChange:
-  enabled: false
+# If restartOnConfigChange flag is enabled, it will add checksum/config annotation to Gateway configMap
+#restartOnConfigChange:
+  #enabled: false
 
 # Number of Gateways to deploy
 replicas: 1

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -33,7 +33,7 @@ imagePullSecret:
 
 # Additional Annotations apply to all deployed objects
 additionalAnnotations: {}
-  #restartOnConfigChange: false
+  # restartOnConfigChange: false
 
 # Additional Labels apply to all deployed objects
 additionalLabels: {}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -54,8 +54,8 @@ rbac:
   create: true
 
 # If restartOnConfigChange flag is enabled, it will add checksum/config annotation to Gateway configMap
-#restartOnConfigChange:
-  #enabled: false
+# restartOnConfigChange:
+  # enabled: false
 
 # Number of Gateways to deploy
 replicas: 1

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -33,7 +33,6 @@ imagePullSecret:
 
 # Additional Annotations apply to all deployed objects
 additionalAnnotations: {}
-  # restartOnConfigChange: false
 
 # Additional Labels apply to all deployed objects
 additionalLabels: {}
@@ -53,6 +52,10 @@ serviceAccount:
 # list/patch permissions for Pods.
 rbac:
   create: true
+
+# If restartOnConfigChange is enabled , it will restart Deployment on ConfigMap change
+restartOnConfigChange:
+  enabled: false
 
 # Number of Gateways to deploy
 replicas: 1

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -33,6 +33,7 @@ imagePullSecret:
 
 # Additional Annotations apply to all deployed objects
 additionalAnnotations: {}
+  #restartOnConfigChange: false
 
 # Additional Labels apply to all deployed objects
 additionalLabels: {}


### PR DESCRIPTION
**Description of the change**

Added restartOnConfigChange flag to trigger Gateway Deployment if configMap changes during helm upgrade

**Benefits**

Example , if User switches from one Database Server to Another , configMap will change and with change , user can control if gateway gets redeployed automatically or manually wants to restart the Gateway pods

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

