### PR TITLE
charts/gateway replace find command

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.14
+version: 3.0.15
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,10 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.15 General Updates
+- Updated [bootstrap script](#bootstrap-script)
+  - 'find' replaced with 'du'
+
 ## 3.0.14 General Updates
 - Added pod labels and annotations to the otk-install job.
   - otk.job.podLabels

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -159,7 +159,7 @@ data:
         echo "***************************************************************************"
         echo "scanning for $TYPE in $SOURCE_DIR"
         echo "***************************************************************************"
-        FILES=$(find $3 -type f -name '*'$2 2>/dev/null)
+        FILES=$(du -a $3 | grep -e ".\\$2$" | awk '{ print $2 }' 2>/dev/null)
         for file in $FILES; do
             name=$(basename "$file")
             cp $file $4/$name
@@ -174,7 +174,7 @@ data:
         echo "***************************************************************************"
         echo "scanning for $TYPE in $SOURCE_DIR"
         echo "***************************************************************************"
-        FILES=$(find $3 -type f -name '*'$2 2>/dev/null)
+        FILES=$(du -a $3 | grep -e ".\\$2$" | awk '{ print $2 }' 2>/dev/null)
         for file in $FILES; do
             name=$(basename "$file")
             echo -e "running $name"


### PR DESCRIPTION
**Description of the change**

Replace find command with du and grep command 

**Benefits**

Works with both centos7 and ubi9-minimal OS

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

