### PR TITLE
[charts/gateway]Make restman host and port modifiable for otk install job

### DIFF
--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -499,6 +499,10 @@ otk:
   # enablePortalIngeration: false
   # skipPostInstallationTasks: false
 
+  # Specify restman host and port
+  # restmanHost:
+  # restmanPort:
+
   # Specify internal gateway host and port for DMZ OTK type
   # internalGatewayHost:
   # internalGatewayPort:

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -96,9 +96,9 @@ spec:
            - name: OTK_CONNECT_RETRY_COUNT
              value: {{ default 10 .Values.otk.connectRetry | quote}}
            - name: SSG_RESTMAN_PORT             
-             value: {{ .Values.installSolutionKits.restmanPort | quote}}
+             value: {{ default 8443 .Values.otk.restmanPort | quote}}
            - name: SSG_RESTMAN_HOST
-             value: {{ template "gateway.fullname" . }}
+             value: {{ .Values.otk.restmanHost | default (template "gateway.fullname" .)}}
            - name: OTK_INTERNAL_GW_HOST
              value: {{ .Values.otk.internalGatewayHost | quote }}
            - name: OTK_INTERNAL_GW_PORT

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -499,6 +499,10 @@ otk:
   # enablePortalIngeration: false
   # skipPostInstallationTasks: false
 
+  # Specify restman host and port
+  # restmanHost:
+  # restmanPort:
+
   # Specify internal gateway host and port for DMZ OTK type
   # internalGatewayHost:
   # internalGatewayPort:


### PR DESCRIPTION
Currently the otk-install job template does not allow to change the restman host or port. This makes it very inflexible for example in our case where we are using a custom loadbalancer and clusterhostname instead of the ingress to make restman available. It's also not possible to patch this job with --post-renderer since it's a post-upgrade,post-install job.

<!-- Describe the scope of your change - i.e. what the change does. -->

Small adjustment on the otk-install job template and the values file

**Benefits**

The benefits of this change will be to make the otk-install job more flexible by parameterizing the restman variables. It will still retain the current values as defaults so it should not be a breaking change.

<!-- What benefits will be realized by the code change? -->

**Drawbacks**
No drawbacks but please double check if the templating code used is correct

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

