### PR TITLE
charts/gateway: Add resources Management  for OTK job

### DIFF
--- a/charts/gateway-otk/Chart.yaml
+++ b/charts/gateway-otk/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gateway-otk
-version: 2.0.2
+version: 2.0.3
 appVersion: "10.1.00"
 description: This alpha Helm Chart deploys the Layer7 Gateway with OTK in Kubernetes.
 maintainers:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.15
+version: 3.0.16
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,6 +37,10 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.16 General Updates
+- Added resources to otk install job
+  - otk.job.resources
+
 ## 3.0.15 General Updates
 - Updated [bootstrap script](#bootstrap-script)
   - 'find' replaced with 'du'
@@ -475,6 +479,7 @@ database:
 | `otk.job.image.tolerations`       | Job tolerations | []
 | `otk.job.podLabels`                   | OTK Job podLabels | {}
 | `otk.job.podAnnotations`              | OTK Job podAnnotations | {}
+| `otk.job.resources`               | OTK Job resources | {}
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -525,6 +525,15 @@ otk:
     # Pod Annotations apply to the OTK install Pod
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     podAnnotations: {}
+
+    resources:
+      requests:
+        memory: 32Mi
+        cpu: 200m
+      limits:
+        memory: 64Mi
+        cpu: 250m
+
   database:
     # OTK database type - mysql/oracle/cassandra
     type: mysql

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -49,6 +49,7 @@ spec:
           {{- if .Values.containerSecurityContext }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
+          resources: {{- toYaml .Values.otk.job.resources | nindent 12 }}
           envFrom:
             - secretRef:
                 name: {{ template "otk.dbSecretName" . }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -525,6 +525,15 @@ otk:
     # Pod Annotations apply to the OTK install Pod
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     podAnnotations: {}
+
+    resources:
+      requests:
+        memory: 32Mi
+        cpu: 200m
+      limits:
+        memory: 64Mi
+        cpu: 250m
+
   database:
     # OTK database type - mysql/oracle/cassandra
     type: mysql

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -527,12 +527,12 @@ otk:
     podAnnotations: {}
 
     resources:
-      requests:
-        memory: 32Mi
-        cpu: 200m
-      limits:
-        memory: 64Mi
-        cpu: 250m
+      requests: {}
+      # memory: 32Mi
+      # cpu: 200m
+      limits: {}
+      # memory: 64Mi
+      # cpu: 250m
 
   database:
     # OTK database type - mysql/oracle/cassandra


### PR DESCRIPTION
**Description of the change**

 Kubernetes Resource Management support for OTK install job.

**Benefits**

Binds the OTK install job by resource limits and requests.

**Drawbacks**
None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

