### PR TITLE
OTK: ScheduleJOB Start IP and Network mask

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -52,7 +52,6 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
   - Added support OTK read-only connections for MySQL and Oracle.
     - otk.database.readOnlyConnection.*
   - Added support for OTK policies customization through config maps and secrets.
-    - otk.customizations.bundle.enabled
     - otk.customizations.existingBundle.enabled
   - OTK DMZ/Internal gateway certs can now be configured using values file.
     - otk.cert
@@ -494,6 +493,8 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.internalGatewayHost`         | Internal gateway host for OTK type DMZ|
 | `otk.internalGatewayPort`         | Internal gateway post for OTK type DMZ|
 | `otk.dmzGatewayHost`              | DMZ gateway host for OTK type INTERNAL|
+| `otk.networkMask`                 | Network mask used in the 'Restrict Access to IP Address Range Assertion' to protect the schedule jobs and health checks.| `16` |
+| `otk.startIP`                 | Start IP used in the 'Restrict Access to IP Address Range Assertion' to protect the schedule jobs and health checks.| `240.224.2.1` |
 | `otk.cert.dmzGatewayCert`         | DMZ gateway certificate (encoded) for OTK type DMZ            |
 | `otk.cert.internalGatewayIssuer`  | DMZ gateway certificate issuer for OTK type DMZ               |
 | `otk.cert.dmzGatewaySerial`       | DMZ gateway certificate serial for OTK type DMZ               |

--- a/charts/gateway/bundles/otk-healthcheck.bundle
+++ b/charts/gateway/bundles/otk-healthcheck.bundle
@@ -43,8 +43,8 @@
     &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
         &lt;L7p:SslAssertion/&gt;
         &lt;L7p:RemoteIpAddressRange&gt;
-            &lt;L7p:NetworkMask stringValue=&quot;16&quot;/&gt;
-            &lt;L7p:StartIp stringValue=&quot;240.224.2.1&quot;/&gt;
+            &lt;L7p:NetworkMask stringValue=&quot;{{ default "16" .Values.otk.networkMask}}&quot;/&gt;
+            &lt;L7p:StartIp stringValue=&quot;{{ default "240.224.2.1" .Values.otk.startIP }}&quot;/&gt;
         &lt;/L7p:RemoteIpAddressRange&gt;
         &lt;L7p:SetVariable&gt;
             &lt;L7p:Base64Expression stringValue=&quot;YWR2YW5jZWQ=&quot;/&gt;

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -75,7 +75,7 @@ pmtagger:
     enabled: false
   resources:
     requests:
-      memory: 64Mi
+      memory: 32Mi
       cpu: 200m
     limits:
       memory: 64Mi
@@ -599,10 +599,10 @@ otk:
 
     resources:
       requests:
-        memory: 32Mi
+        memory: 64Mi
         cpu: 200m
       limits:
-        memory: 64Mi
+        memory: 128Mi
         cpu: 250m
 
   database:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -514,6 +514,12 @@ otk:
   # dmzGatewayHost:
   # dmzGatewayPort:
 
+  # Network mask and startIP used in the 'Restrict Access to IP Address Range Assertion' to protect the schedule jobs and health checks.
+  # The db maintenance and health check services can accessible based on the IP address.
+  # https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-1/policy-assertions/assertion-palette/service-availability-assertions/restrict-access-to-ip-address-range-assertion.html
+  # networkMask: 16
+  # startIP: 240.224.2.1
+
   cert:
     # Specify DMZ gateway certificates that needs to be imported to Internal GW (for ephemeral gateway)
     # dmzGatewayCert:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -75,7 +75,7 @@ pmtagger:
     enabled: false
   resources:
     requests:
-      memory: 32Mi
+      memory: 64Mi
       cpu: 200m
     limits:
       memory: 64Mi

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -90,10 +90,6 @@ spec:
             {{ end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.otk.customizations.bundle.enabled }}
-          - name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
-            mountPath: /docker/custom_bundles/configmap
-          {{- end }}
       {{- end }}
       {{- if .Values.initContainers }}
       {{toYaml .Values.initContainers | nindent 6 }}
@@ -578,13 +574,6 @@ spec:
 {{ if and (.Values.otk.enabled) (not .Values.database.enabled) }}
         - name: {{ template "gateway.fullname" . }}-otk-install-container
           emptyDir: {}
-        {{- if .Values.otk.customizations.bundle.enabled }}
-        - name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
-          configMap:
-            defaultMode: 292
-            optional: false
-            name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
-        {{- end }}
         {{- if .Values.otk.customizations.existingBundle.enabled }}
         {{- range .Values.otk.customizations.existingBundle.configMaps }}
         - name: {{ .name }}

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -89,10 +89,10 @@ spec:
         - name: {{ template "otk.imagePullSecret" . }}
       {{- end }}
       {{- if .Values.otk.job.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.otk.jobs.nodeSelector | nindent 12 }}
+      nodeSelector: {{- toYaml .Values.otk.job.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.otk.job.tolerations }}
-      tolerations: {{- toYaml .Values.otk.jobs.tolerations | nindent 12 }}
+      tolerations: {{- toYaml .Values.otk.job.tolerations | nindent 6 }}
       {{- end }}
       restartPolicy: "Never"
       {{ end }}

--- a/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
+++ b/charts/gateway/templates/otk-healthcheck-bundle-configmap.yaml
@@ -64,8 +64,8 @@ data:
         &lt;wsp:All wsp:Usage=&quot;Required&quot;&gt;
             &lt;L7p:SslAssertion/&gt;
             &lt;L7p:RemoteIpAddressRange&gt;
-                &lt;L7p:NetworkMask stringValue=&quot;16&quot;/&gt;
-                &lt;L7p:StartIp stringValue=&quot;240.224.2.1&quot;/&gt;
+                &lt;L7p:NetworkMask stringValue=&quot;{{ default "16" .Values.otk.networkMask}}&quot;/&gt;
+                &lt;L7p:StartIp stringValue=&quot;{{ default "240.224.2.1" .Values.otk.startIP }}&quot;/&gt;
             &lt;/L7p:RemoteIpAddressRange&gt;
             &lt;L7p:SetVariable&gt;
                 &lt;L7p:Base64Expression stringValue=&quot;YWR2YW5jZWQ=&quot;/&gt;

--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -96,4 +96,6 @@ data:
   OTK_DMZ_GW_PORT: {{ default "" .Values.otk.dmzGatewayPort| quote }}
   OTK_INTEGRATE_WITH_PORTAL: {{default false .Values.otk.enablePortalIntegration | quote }}
   OTK_SKIP_POST_INSTALLATION_TASKS: {{default false .Values.otk.skipPostInstallationTasks | quote }}
+  OTK_DBMAINTENANCE_NET_MASK: {{ default "16" .Values.otk.networkMask| quote }}
+  OTK_DBMAINTENANCE_START_IP: {{ default "240.224.2.1" .Values.otk.startIP | quote }}
 {{- end }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -62,10 +62,6 @@ spec:
             {{ end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.otk.customizations.bundle.enabled }}
-          - name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
-            mountPath: /docker/custom_bundles/configmap
-          {{- end }}
 
           resources: {{- toYaml .Values.otk.job.resources | nindent 12 }}
           envFrom:
@@ -102,13 +98,6 @@ spec:
             secretName: {{ .name }}
           {{- end }}
         {{- end }}
-        {{- end }}
-        {{- if .Values.otk.customizations.bundle.enabled }}
-        - name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
-          configMap:
-            defaultMode: 292
-            optional: false
-            name: {{ template "gateway.fullname" . }}-otk-bundle-configmap
         {{- end }}
 
       {{- if .Values.otk.job.nodeSelector }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -101,7 +101,7 @@ spec:
         {{- end }}
 
       {{- if .Values.otk.job.nodeSelector }}
-      nodeSelector: {{- toYaml .Values.otk.jobs.nodeSelector | nindent 12 }}
+      nodeSelector: {{- toYaml .Values.otk.job.nodeSelector | nindent 8 }}
       {{- end }}
 
       {{- if or (.Values.imagePullSecret.enabled) (.Values.otk.job.imagePullSecret.enabled) }}
@@ -110,7 +110,7 @@ spec:
       {{- end }}
 
       {{- if .Values.otk.job.tolerations }}
-      tolerations: {{- toYaml .Values.otk.jobs.tolerations | nindent 12 }}
+      tolerations: {{- toYaml .Values.otk.job.tolerations | nindent 8 }}
       {{- end }}
 
       restartPolicy: "Never"

--- a/charts/gateway/templates/otk-scheduled-task-jobs.yaml
+++ b/charts/gateway/templates/otk-scheduled-task-jobs.yaml
@@ -44,19 +44,19 @@ spec:
           securityContext: {{- toYaml $.Values.podSecurityContext | nindent 12 }}
           {{- end }}
           containers:
-          - name: schedule-task
-            image: curlimages/curl:7.72.0
-            {{- if $.Values.containerSecurityContext }}
-            securityContext: {{- toYaml $.Values.containerSecurityContext | nindent 14 }}
-            {{- end }}
+          - name: otk-schedule-task
+            image: {{ template "otk.image" . }}
             imagePullPolicy: {{ .Values.otk.job.image.pullPolicy }}
             resources: {{- toYaml .Values.otk.job.resources | nindent 12 }}
-            command:
-            - /bin/sh
-            - -c
-            - "curl -v --request POST 'https://{{ template "gateway.fullname" $ }}:8443/oauth/db-maintenance?task={{ .name }}' --insecure"
-
-          {{- if .Values.otk.job.nodeSelector }}
+            {{- if .Values.containerSecurityContext }}
+            securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+            {{- end }}
+            env:
+            - name: SCHEDULE_TASK_URL
+              value: https://{{ template "gateway.fullname" $ }}:8443/oauth/db-maintenance?task={{ .name }}
+            - name: OTK_SCHEDULE_JOB_SERVICE
+              value: "true"
+           {{- if .Values.otk.job.nodeSelector }}
           nodeSelector: {{- toYaml .Values.otk.jobs.nodeSelector | nindent 12 }}
           {{- end }}
 

--- a/charts/gateway/templates/otk-scheduled-task-jobs.yaml
+++ b/charts/gateway/templates/otk-scheduled-task-jobs.yaml
@@ -45,28 +45,29 @@ spec:
           {{- end }}
           containers:
           - name: otk-schedule-task
-            image: {{ template "otk.image" . }}
-            imagePullPolicy: {{ .Values.otk.job.image.pullPolicy }}
-            resources: {{- toYaml .Values.otk.job.resources | nindent 12 }}
-            {{- if .Values.containerSecurityContext }}
-            securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+            image: {{ template "otk.image" $ }}
+            imagePullPolicy: {{ $.Values.otk.job.image.pullPolicy }}
+            resources: {{- toYaml $.Values.otk.job.resources | nindent 14 }}
+            {{- if $.Values.containerSecurityContext }}
+            securityContext: {{- toYaml $.Values.containerSecurityContext | nindent 14 }}
             {{- end }}
             env:
             - name: SCHEDULE_TASK_URL
               value: https://{{ template "gateway.fullname" $ }}:8443/oauth/db-maintenance?task={{ .name }}
             - name: OTK_SCHEDULE_JOB_SERVICE
               value: "true"
-           {{- if .Values.otk.job.nodeSelector }}
-          nodeSelector: {{- toYaml .Values.otk.jobs.nodeSelector | nindent 12 }}
+          
+          {{- if $.Values.otk.job.nodeSelector }}
+          nodeSelector: {{- toYaml $.Values.otk.job.nodeSelector | nindent 12 }}
           {{- end }}
 
-          {{- if or (.Values.imagePullSecret.enabled) (.Values.otk.job.imagePullSecret.enabled) }}
+          {{- if or ($.Values.imagePullSecret.enabled) ($.Values.otk.job.imagePullSecret.enabled) }}
           imagePullSecrets:
-            - name: {{ template "otk.imagePullSecret" . }}
+            - name: {{ template "otk.imagePullSecret" $ }}
           {{- end }}
 
-          {{- if .Values.otk.job.tolerations }}
-          tolerations: {{- toYaml .Values.otk.jobs.tolerations | nindent 12 }}
+          {{- if $.Values.otk.job.tolerations }}
+          tolerations: {{- toYaml $.Values.otk.job.tolerations | nindent 10 }}
           {{- end }}
 
           restartPolicy: Never

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -602,7 +602,7 @@ otk:
       # memory: 64Mi
       # cpu: 200m
       limits: {}
-      # memory: 64Mi
+      # memory: 128Mi
       # cpu: 250m
 
   database:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -599,7 +599,7 @@ otk:
 
     resources:
       requests: {}
-      # memory: 32Mi
+      # memory: 64Mi
       # cpu: 200m
       limits: {}
       # memory: 64Mi

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -374,7 +374,7 @@ clusterHostname: my.localdomain
 # Database configuration
 database:
   # DB Backed or ephemeral
-  enabled: false
+  enabled: true
   # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
   # Do not use this demo database in production!!!
   create: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -374,7 +374,7 @@ clusterHostname: my.localdomain
 # Database configuration
 database:
   # DB Backed or ephemeral
-  enabled: true
+  enabled: false
   # A MySQL Database is configured with this Chart, set to false and set jdbcURL to use your own DB server
   # Do not use this demo database in production!!!
   create: true
@@ -513,6 +513,12 @@ otk:
   # Specify DMZ gateway host and port for internal OTK type
   # dmzGatewayHost:
   # dmzGatewayPort:
+
+  # Network mask and startIP used in the 'Restrict Access to IP Address Range Assertion' to protect the schedule jobs and health checks.
+  # The db maintenance and health check services can accessible based on the IP address.
+  # https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-1/policy-assertions/assertion-palette/service-availability-assertions/restrict-access-to-ip-address-range-assertion.html
+  # networkMask: 16
+  # startIP: 240.224.2.1
 
   cert:
     # Specify DMZ gateway certificates that needs to be imported to Internal GW (for ephemeral gateway)


### PR DESCRIPTION
**Description of the change**

1. Schedule JOB Service protected by configurable "'Restrict Access to IP Address Range Assertion"
2. Use install job docker image for Schedule jobs.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

