### PR TITLE
charts/gateway update to Gateway image to v11.0.00_CR2 [DO NOT MERGE]

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "11.0.00_CR1"
+appVersion: "11.0.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.19
+version: 3.0.20
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -38,6 +38,11 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
 
+## 3.0.20 General Updates
+- Updated image
+  - Updated to Gateway 11.0.00_CR2
+    - this will cause a restart if you are not overriding the default image
+
 ## 3.0.19 General Updates
 - Updated image
   - Updated to Gateway 11.0.00_CR1

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -12,7 +12,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 11.0.00_CR1
+  tag: 11.0.00_CR2
   pullPolicy: IfNotPresent
 
 # If you are using a Hazelcast 3.x server then you need to set hazelcast.legacy.enabled=true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -12,7 +12,7 @@ license:
 image:
   registry: docker.io
   repository: caapim/gateway
-  tag: 11.0.00_CR1
+  tag: 11.0.00_CR2
   pullPolicy: IfNotPresent
 
 # If you are using a Hazelcast 3.x server then you need to set hazelcast.legacy.enabled=true


### PR DESCRIPTION
**Description of the change**
Update the Gateway image to v11.0.00_CR2

**Benefits**
Take advantage of the latest container gateway release

**Drawbacks**
- A Gateway restart will be required
- The new base image may not work with some custom scripts


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

