### PR TITLE
Added 'real' init scripts to run before anything else

### DIFF
--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -193,6 +193,37 @@ data:
     copy "custom properties" ".properties" $CUSTOM_PROPERTIES_DIR $TARGET_CUSTOM_PROPERTIES_DIR
     copy "custom health checks" ".sh" $CUSTOM_HEALTHCHECK_SCRIPTS_DIR $TARGET_HEALTHCHECK_DIR
     run "custom shell scripts" ".sh" $CUSTOM_SHELL_SCRIPTS_DIR
+  003-parse-init: |-
+    #!/bin/bash
+    BASE_CONFIG_DIR="/opt/docker/custom"
+    CUSTOM_SHELL_SCRIPTS_DIR="$BASE_CONFIG_DIR/init-scripts"
+
+    error() {
+            # Send errors to stderr in case these get handled differently by the container PaaS on which this runs
+            echo "ERROR - ${1}" 1>&2
+            exit 1
+    }
+
+    function run() {
+        TYPE=$1
+        EXT=$2
+        SOURCE_DIR=$3
+        echo "***************************************************************************"
+        echo "scanning for $TYPE in $SOURCE_DIR"
+        echo "***************************************************************************"
+        FILES=$(du -a $3 | grep -e ".\\$2$" | awk '{ print $2 }' 2>/dev/null)
+        for file in $FILES; do
+            name=$(basename "$file")
+            echo -e "running $name"
+            /bin/bash $file
+            if [ $? -ne 0 ]; then
+              echo "Failed executing the script: $file"
+              exit 1
+            fi
+        done
+    }
+
+    run "custom init shell scripts" ".sh" $CUSTOM_SHELL_SCRIPTS_DIR
 {{- end}}
 {{- if .Values.preStopScript.enabled }}
   gracefulshutdown: |-

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -294,6 +294,9 @@ spec:
             - name: {{ template "gateway.fullname" . }}-parse-custom-files-script
               mountPath: /opt/docker/rc.d/003-parse-custom-files.sh
               subPath: 003-parse-custom-files.sh
+            - name: {{ template "gateway.fullname" . }}-parse-init-script
+              mountPath: /opt/docker/init.d/003-parse-init.sh
+              subPath: 003-parse-init.sh
 {{- end }}
 {{- end }}
 {{- if .Values.preStopScript }}
@@ -552,6 +555,12 @@ spec:
             items:
             - key: 003-parse-custom-files
               path: 003-parse-custom-files.sh
+        - name: {{ template "gateway.fullname" . }}-parse-init-script
+          configMap:
+            name: {{ template "gateway.fullname" . }}-configmap
+            items:
+            - key: 003-parse-init
+              path: 003-parse-init.sh
 {{- end }}
 {{- end }}
 {{- if .Values.preStopScript }}


### PR DESCRIPTION
Added 'real' init scripts to run before anything else, (ex: patching liquibase files for mariadb for example), also need modification to main gw entrypoint.sh, will share through email.

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Add capability to run user-defined scripts from init container at boot time, before anything else.

<!-- What benefits will be realized by the code change? -->

Allow to customize before GW pre-init.

<!-- Describe any known limitations with your change -->

N/A

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

N/A

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->


