### PR TITLE
[charts/portal]Removing the redundant javaoptions for portal-data pod and adding customprobes to RMQ to ramup the boot time

### DIFF
--- a/charts/portal/templates/portal-data/portal-data-config.yaml
+++ b/charts/portal/templates/portal-data/portal-data-config.yaml
@@ -25,10 +25,9 @@ data:
   DATABASE_REQUIRE_SSL: {{ .Values.global.databaseRequireSSL | quote }}
   FILE_REPOSITORY_DATABASE_NAME: {{ include "portal-db-name" . | quote }}
   HELP_BASE_URL: {{ include "portal.help.page" . | quote }}
-  JAVA_OPTIONS: {{ .Values.portalData.javaOptions | default "-Xms2g -Xmx2g" | quote }}
+  JAVA_OPTIONS: {{ .Values.portalData.javaOptions | default "-Xms2048m -Xmx2048m" | quote }}
   # TODO: Find out why this is hardcoded, can it be ommitted??
   HOST_NAME_ID: MTAuMTc1LjI0Ny4yNDQgMTcyLjE4LjAuMSAxNzIuMTcuMC4xIAo=
-  JAVA_OPTIONS: -Xms2048m -Xmx2048m
   NSS_SDB_USE_CACHE: "no"
   PAPI_PUBLIC_HOST: {{ include "tssg-public-host" . | quote }}
   PORTAL_SUBDOMAIN: {{ required "Please fill in domain in values.yaml" .Values.portal.domain | quote }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -366,7 +366,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 2
-  javaOptions: -Xms2g -Xmx2g
+  javaOptions: -Xms2048m -Xmx2048m
   image:
     pullPolicy: IfNotPresent
   pdb:
@@ -925,6 +925,18 @@ rabbitmq:
     requests:
       cpu: 1000m
       memory: 2Gi
+  customLivenessProbe:
+   exec:
+    command:
+      - sh
+      - -ec
+      - curl -f  --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/virtual-hosts
+  customReadinessProbe:
+   exec:
+    command:
+      - sh
+      - -ec
+      - curl -f  --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/local-alarms
 
 # Settings for Nginx-Ingress - https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 ingress-nginx:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -332,7 +332,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 1
-  javaOptions: -Xms2g -Xmx2g
+  javaOptions: -Xms2048m -Xmx2048m
   image:
     pullPolicy: IfNotPresent
   pdb:
@@ -771,7 +771,18 @@ rabbitmq:
     requests: {}
     # cpu: 1000m
     # memory: 2Gi
-
+  customLivenessProbe:
+   exec:
+    command:
+      - sh
+      - -ec
+      - curl -f  --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/virtual-hosts
+  customReadinessProbe:
+   exec:
+    command:
+      - sh
+      - -ec
+      - curl -f  --user {{ .Values.auth.username }}:$RABBITMQ_PASSWORD 127.0.0.1:{{ .Values.containerPorts.manager }}/api/health/checks/local-alarms
 
 # Settings for Nginx-Ingress - https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 ingress-nginx:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

