### PR TITLE
[charts/portal] Changes to remove the redundant java_options  of portal-data container

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.2.2"
 description: CA API Developer Portal
 name: portal
-version: 2.3.4
+version: 2.3.5
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/templates/portal-data/portal-data-config.yaml
+++ b/charts/portal/templates/portal-data/portal-data-config.yaml
@@ -25,10 +25,9 @@ data:
   DATABASE_REQUIRE_SSL: {{ .Values.global.databaseRequireSSL | quote }}
   FILE_REPOSITORY_DATABASE_NAME: {{ include "portal-db-name" . | quote }}
   HELP_BASE_URL: {{ include "portal.help.page" . | quote }}
-  JAVA_OPTIONS: {{ .Values.portalData.javaOptions | default "-Xms2g -Xmx2g" | quote }}
+  JAVA_OPTIONS: {{ .Values.portalData.javaOptions | default "-Xms2048m -Xmx2048m" | quote }}
   # TODO: Find out why this is hardcoded, can it be ommitted??
   HOST_NAME_ID: MTAuMTc1LjI0Ny4yNDQgMTcyLjE4LjAuMSAxNzIuMTcuMC4xIAo=
-  JAVA_OPTIONS: -Xms2048m -Xmx2048m
   NSS_SDB_USE_CACHE: "no"
   PAPI_PUBLIC_HOST: {{ include "tssg-public-host" . | quote }}
   PORTAL_SUBDOMAIN: {{ required "Please fill in domain in values.yaml" .Values.portal.domain | quote }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -341,7 +341,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 2
-  javaOptions: -Xms2g -Xmx2g
+  javaOptions: -Xms2048m -Xmx2048m
   image:
     pullPolicy: IfNotPresent
   pdb:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -307,7 +307,7 @@ dispatcher:
 portalData:
   forceRedeploy: false
   replicaCount: 1
-  javaOptions: -Xms2g -Xmx2g
+  javaOptions: -Xms2048m -Xmx2048m
   image:
     pullPolicy: IfNotPresent
   pdb:


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

