### PR TITLE
charts/gateway added customInit and Sidecar volumes

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.23
+version: 3.0.24
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -66,6 +66,12 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.24 General Updates
+- Custom Volumes for initContainers and Sidecars
+  - This allows configmaps/secrets to be mounted to initContainers and sideCars
+    - customSideCarVolumes
+    - customInitVolumes
+
 ## 3.0.23 OTK 4.6.2_202402 Released 
 - Updated OTK image version value
 

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -973,6 +973,14 @@ sidecars: []
 ##         containerPort: 1234
 ##
 
+# customSideCarVolumes applies to sidecars. By default volumes of type emptyDir are automatically created for sidecars and initContainers. This config allows you to override that
+# Filtering is done by name, make sure that the volumeMount and volume names are the same.
+customSideCarVolumes: []
+
+# customInitVolumes applies to initContainers. By default volumes of type emptyDir are automatically created for volumeMounts in initContainers. This config allows you to override that
+# Filtering is done by name, make sure that the volumeMount and volume names are the same.
+customInitVolumes: []
+
 # Configure custom hosts
 customHosts:
   enabled: false

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -319,15 +319,28 @@ spec:
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
 {{- end }}
 {{- if .Values.sidecars }}
-           {{- range .Values.sidecars }}
-           {{- range .volumeMounts }}
+         {{- range .Values.sidecars }}
+         {{- range .volumeMounts }}
+         {{- $vn := .name }}
+         {{ $duplicate := false}}
+         {{- if $.Values.initContainers}}
+           {{- range $_,$ic := $.Values.initContainers }}
+             {{- range $_,$icvm := $ic.volumeMounts }}
+               {{- if eq $vn $icvm.name }}
+                 {{ $duplicate = true}}
+               {{- end }}
+             {{- end }}
+           {{- end }}
+         {{- end }}
+         {{ if not $duplicate }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               {{ if .subPath }}
               subPath: {{ .subPath }}
               {{ end }}
-           {{- end }}
-           {{- end }}
+         {{- end }}
+         {{- end }}
+         {{- end }}
 {{- end }}
           envFrom:
             - configMapRef:
@@ -608,9 +621,27 @@ spec:
 {{- end }}
 {{- if .Values.initContainers }}
      {{- range .Values.initContainers }}
+     {{- $cvIndex := 0 }}
      {{- range .volumeMounts }}
-        - name: {{ .name }}
+       {{- $vn := .name }}
+       {{- $found := false }}
+       {{- $cvIndex = 0 }}
+       {{- if $.Values.customInitVolumes }}
+       {{- range $i,$cv := $.Values.customInitVolumes }}
+       {{- if eq $vn $cv.name }}
+        {{- $found = true }}
+        {{- $cvIndex = $i }}
+       {{- end }}
+       {{- end }}
+       {{- end }}
+       {{- if eq $found true }}
+        {{- with (index $.Values.customInitVolumes $cvIndex) }}
+        - {{- toYaml . | nindent 10}}
+        {{- end }}
+      {{- else }}
+        - name: {{ $vn }}
           emptyDir: {}
+      {{- end }}
      {{- end }}
      {{- end }}
 {{- end }}
@@ -642,9 +673,39 @@ spec:
 {{- end }}
 {{- if .Values.sidecars }}
      {{- range .Values.sidecars }}
+     {{- $cvIndex := 0 }}
      {{- range .volumeMounts }}
-        - name: {{ .name }}
+       {{- $vn := .name }}
+       {{- $found := false }}
+       {{- $duplicate := false }}
+       {{- $cvIndex = 0 }}
+      {{- if $.Values.initContainers }}
+        {{- range  $_,$ic :=  $.Values.initContainers }}
+          {{- range $_,$icvm :=  $ic.volumeMounts }}
+            {{- if eq $vn $icvm.name }}
+              {{- $duplicate = true }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+       {{- if $.Values.customSideCarVolumes }}
+         {{- range $i,$cv := $.Values.customSideCarVolumes }}
+         {{- if eq $vn $cv.name }}
+           {{- $found = true }}
+           {{- $cvIndex = $i }}
+         {{- end }}
+         {{- end }}
+       {{- end }}
+       {{- if not $duplicate }}
+       {{- if $found }}
+        {{- with (index $.Values.customSideCarVolumes $cvIndex) }}
+        - {{- toYaml . | nindent 10}}
+        {{- end }}
+      {{- else }}
+        - name: {{ $vn }}
           emptyDir: {}
+      {{- end }}
+     {{- end }}
      {{- end }}
      {{- end }}
 {{- end }}

--- a/charts/gateway/templates/pm-tagger-deployment.yaml
+++ b/charts/gateway/templates/pm-tagger-deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: {{ template "gateway.imagePullSecret" . }}
 {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-pm-tagger
           image: {{.Values.pmtagger.image.registry}}/{{.Values.pmtagger.image.repository}}:{{.Values.pmtagger.image.tag}}
           imagePullPolicy: {{ .Values.pmtagger.image.pullPolicy }}
           {{- if .Values.pmtagger.containerSecurityContext }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -973,6 +973,14 @@ sidecars: []
 ##         containerPort: 1234
 ##
 
+# customSideCarVolumes applies to sidecars. By default volumes of type emptyDir are automatically created for sidecars and initContainers. This config allows you to override that
+# Filtering is done by name, make sure that the volumeMount and volume names are the same.
+customSideCarVolumes: []
+
+# customInitVolumes applies to initContainers. By default volumes of type emptyDir are automatically created for volumeMounts in initContainers. This config allows you to override that
+# Filtering is done by name, make sure that the volumeMount and volume names are the same.
+customInitVolumes: []
+
 # Configure custom hosts
 customHosts:
   enabled: false


### PR DESCRIPTION
**Description of the change**
- Custom Volumes for initContainers and Sidecars
  - This allows configmaps/secrets to be mounted to initContainers and sideCars
    - customSideCarVolumes
    - customInitVolumes
- Updated the pmtagger container name

**Benefits**
Configmaps/Secrets can be mounted to initContainers and sidecars. Previously this would always be emptyDir


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

