### PR TITLE
[charts/gateway] OTK db maintenance schedule job history

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.0.00_CR2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.24
+version: 3.0.25
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -67,7 +67,7 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
 ## 3.0.25 OTK Schedule job success and failure limts
-- Added sucess and failure job limit for OTK database maintenance schedule jobs 
+- Added configurable success and failure job history limit for OTK database maintenance schedule jobs.
 
 ## 3.0.24 General Updates
 - Custom Volumes for initContainers and Sidecars

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -66,6 +66,9 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.25 OTK Schedule job success and failure limts
+- Added sucess and failure job limit for OTK database maintenance schedule jobs 
+
 ## 3.0.24 General Updates
 - Custom Volumes for initContainers and Sidecars
   - This allows configmaps/secrets to be mounted to initContainers and sideCars
@@ -603,6 +606,8 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.job.podLabels`               | OTK Job podLabels | {}
 | `otk.job.podAnnotations`          | OTK Job podAnnotations | {}
 | `otk.job.resources`               | OTK Job resources | {}
+| `otk.job.scheduledTasksSuccessfulJobsHistoryLimit`| OTK db maintenance scheduled job success history limit | `1` |
+| `otk.job.scheduledTasksFailedJobsHistoryLimit`| OTK db maintenance scheduled job failed history limit | `1` |
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -647,6 +647,9 @@ otk:
       - name: miscellaneous
         schedule: "*/5 * * * *"
 
+    scheduledTasksSuccessfulJobsHistoryLimit: 1
+    scheduledTasksFailedJobsHistoryLimit: 1
+
     labels: {}
     # nodeSelector: {}
     # tolerations: []

--- a/charts/gateway/templates/otk-scheduled-task-jobs.yaml
+++ b/charts/gateway/templates/otk-scheduled-task-jobs.yaml
@@ -25,7 +25,8 @@ metadata:
 spec:
   schedule: {{ .schedule | quote }}
   concurrencyPolicy: "Forbid"
-  successfulJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: {{ default 1 $.Values.otk.job.scheduledTasksSuccessfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 1 $.Values.otk.job.scheduledTasksFailedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:
@@ -69,7 +70,6 @@ spec:
           {{- if $.Values.otk.job.tolerations }}
           tolerations: {{- toYaml $.Values.otk.job.tolerations | nindent 10 }}
           {{- end }}
-
           restartPolicy: Never
 ---
 {{- end }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- end }}
   {{- if  .Values.additionalAnnotations }}
   annotations:
-  "helm.sh/hook": pre-install,post-upgrade
-  "helm.sh/hook-weight": "-5"
+    "helm.sh/hook": pre-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
 {{- range $key, $val := .Values.additionalAnnotations }}
     {{ $key }}: "{{ $val }}"
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -647,6 +647,9 @@ otk:
       - name: miscellaneous
         schedule: "*/5 * * * *"
 
+    scheduledTasksSuccessfulJobsHistoryLimit: 1
+    scheduledTasksFailedJobsHistoryLimit: 1
+
     labels: {}
     # nodeSelector: {}
     # tolerations: []


### PR DESCRIPTION
**Description of the change**

OTK installation on ephemeral GW requires db maintenance schedule job to be run as k8s CronJob. Added ability to configure the success and failure history limit which controls the number of success and failure jobs to be kept.

**Benefits**

Customers will be able to keep the desired history of the jobs.

**Drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

