### PR TITLE
[charts/gateway] added a startup probe for the gateway deployment

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.1.00"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.27
+version: 3.0.28
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -95,6 +95,10 @@ The Layer7 API Gateway is now running with Java 11 with the release of the v10.1
 
 Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JAVA_HOME dir has gone through some changes as well.
 
+## 3.0.28 General Updates
+- Added a [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Gateway Container.
+  - Disabled by default
+
 ## 3.0.27 General Updates
 - Default image updated to v11.1.00
   - Due to conflicting embedded Hazelcast versions between Gateway 10.x and 11.1, and between 11.0 and 11.1, a rolling update cannot be performed when upgrading to version 11.1 GA. Instead, follow the alternative steps:
@@ -497,6 +501,12 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `ingress.tlsHostnames`    | Register additional Hostnames for the TLS Certificate  | `see values.yaml` |
 | `ingress.secretName`    | The name of an existing Cert secret, setting this does not auto-create the secret               | `tls-secret` |
 | `ingress.additionalHostnamesAndPorts`    | key/value pairs of hostname:port that will be added to the ingress object  | `see values.yaml` |
+| `startupProbe.enabled`    | Enable/Disable               | `false` |
+| `startupProbe.initialDelaySeconds`    | Initial delay               | `60` |
+| `startupProbe.timeoutSeconds`    | Timeout               | `1` |
+| `startupProbe.periodSeconds`    | Frequency               | `10` |
+| `startupProbe.successThreshold`    | Success Threshold               | `1` |
+| `startupProbe.failureThreshold`    | Failure Threshold               | `10` |
 | `livenessProbe.enabled`    | Enable/Disable               | `true` |
 | `livenessProbe.initialDelaySeconds`    | Initial delay               | `60` |
 | `livenessProbe.timeoutSeconds`    | Timeout               | `1` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -927,6 +927,22 @@ bundle:
   enabled: false
   path: "bundles/*.bundle"
 
+startupProbe:
+  enabled: false
+  type: command
+  command: /opt/docker/rc.d/diagnostic/health_check.sh
+# type: httpGet
+# path: /ssg/ping
+# port: 8443
+# scheme: HTTPS
+# httpHeaders: []
+  initialDelaySeconds: 20
+  timeoutSeconds: 1
+  periodSeconds: 15
+  successThreshold: 1
+  failureThreshold: 15
+
+
 livenessProbe:
   enabled: true
   type: command

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -351,6 +351,31 @@ spec:
             - secretRef:
                 name: {{ template "gateway.tlsSecretName" . }}
 {{- end }}
+
+{{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            {{- if eq .Values.startupProbe.type "httpGet"}}
+            httpGet:
+              path: {{ .Values.startupProbe.path | default "/ssg/ping"}}
+              port: {{ .Values.startupProbe.port | default 8443 }}
+              scheme: {{ .Values.startupProbe.scheme | default "HTTPS" }}
+              httpHeaders:
+              {{- range.Values.startupProbe.httpHeaders }}
+              - name: {{ .name }}
+                value: {{ .value }}
+              {{- end }}
+            {{- else }}
+            exec:
+              command:
+              - /bin/bash
+              - {{ .Values.startupProbe.command | default "/opt/docker/rc.d/diagnostic/health_check.sh" }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+{{- end }}
 {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
 {{- if and (.Values.otk.enabled) (.Values.otk.livenessProbe.enabled) }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -927,6 +927,21 @@ bundle:
   enabled: false
   path: "bundles/*.bundle"
 
+startupProbe:
+  enabled: false
+  type: command
+  command: /opt/docker/rc.d/diagnostic/health_check.sh
+# type: httpGet
+# path: /ssg/ping
+# port: 8443
+# scheme: HTTPS
+# httpHeaders: []
+  initialDelaySeconds: 20
+  timeoutSeconds: 1
+  periodSeconds: 15
+  successThreshold: 1
+  failureThreshold: 15
+
 livenessProbe:
   enabled: true
   type: command


### PR DESCRIPTION
**Description of the change**
## 3.0.28 General Updates
- Added a [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Gateway Container.
  - Disabled by default

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

