### PR TITLE
[charts/gateway] Add disklessConfig property

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1188,22 +1188,17 @@ node.db.config.main.user=gateway
 ```
 
 - Mounting a pre-configured node.properties to container gateway
-  - Referenced via existingGatewaySecretName
-  - In following example , pre-existing secret is  node-properties-secret
-  
+
 ```
-customConfig:
+disklessConfig:
   enabled: true
-  mounts:
-  - name: node-properties-override
-    mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
-    subPath: node.properties
-    secret:
-      name: node-properties-secret
-      item:
-        key: node.properties
-        path: node.properties
+  value:
+  # existingSecretName:
 ```
+- Use set file to place a node.properties here
+ ```
+helm install my-ssg --set-file "license.value=license.value=path/to/license.xml" --set "disklessConfig.enabled=true" --set-file "disklessConfig.value=license.value=path/to/node.properties" --set "license.accept=true"layer7/gateway  ./values.yaml
+ ```
 
 ### Bundle Configuration
 There are a variety of ways to mount Gateway (Restman format) Bundles to the Gateway Container. The best option is making use of existingBundles where the bundle has been created ahead of deployment as a configMap or secret.

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -73,6 +73,7 @@ Helm Version    Supported Kubernetes Versions
 * [Cluster-Wide Properties](#cluster-wide-properties)
 * [Java Args](#java-args)
 * [System Properties](#system-properties)
+* [Diskless Cofiguration](#diskless-configuration)
 * [Gateway Bundles](#bundle-configuration)
 * [Bootstrap Script](#bootstrap-script)
 * [Custom Health Checks](#custom-health-checks)
@@ -1157,6 +1158,50 @@ The full default is this
     # Period of time before the Gateway removes inactive nodes.
     com.l7tech.server.clusterStaleNodeCleanupTimeoutSeconds=86400
     # Additional properties go here
+```
+### DISKLESS Configuraton
+DISKLESS_CONFIG is a flag to pass gateway sensitive data to be mounted to the container gateway file system or passed as environment variables.
+By Default, true, environment variables are used to configure Gateway.
+
+When DISKLESS_CONFIG is disabled , Gateway will be configured from node.properties
+
+#### node.properties
+Note: 
+- Database configuration should be same as mentioned in node.properties
+```
+node.cluster.pass=newpassword
+admin.user=admin
+admin.pass=newpassword
+node.db.config.main.host=<Replace with jdbc-url>
+node.db.config.main.port=3306
+node.db.config.main.name=ssg
+node.db.config.main.user=gateway
+node.db.config.main.pass=newpassword
+```
+- For derby database, it is required to add ***node.db.type=derby*** to node.properties
+```
+node.cluster.pass=newpassword
+admin.user=admin
+admin.pass=newpassword
+node.db.type=derby
+```
+
+- Mounting a pre-configured node.properties to container gateway
+  - Referenced via existingGatewaySecretName
+  - In following example , pre-existing secret is  node-properties-secret
+  
+```
+customConfig:
+  enabled: true
+  mounts:
+  - name: node-properties-override
+    mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
+    subPath: node.properties
+    secret:
+      name: node-properties-secret
+      item:
+        key: node.properties
+        path: node.properties
 ```
 
 ### Bundle Configuration

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -439,6 +439,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `global.schedulerName`                      | Override the default scheduler | `nil` |
 | `license.value`          | Gateway license file | `nil`  |
 | `license.accept`          | Accept Gateway license EULA | `false`  |
+| `disklessConfig`          | Boolean value whether to use diskless configuration for Gateway or not. When true, environment variables are used to configure Gateway. When false, node.properties is used. | `true` |
 | `image.registry`    | Image Registry               | `docker.io` |
 | `image.repository`          | Image Repository  | `caapim/gateway`  |
 | `image.tag`          | Image tag | `11.0.00`  |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1163,7 +1163,7 @@ The full default is this
 DISKLESS_CONFIG is a flag to pass gateway sensitive data to be mounted to the container gateway file system or passed as environment variables.
 By Default, true, environment variables are used to configure Gateway.
 
-When DISKLESS_CONFIG is disabled , Gateway will be configured from node.properties
+When DISKLESS_CONFIG is false , Gateway will be configured from node.properties
 
 #### node.properties
 Note: 
@@ -1172,7 +1172,7 @@ Note:
 node.cluster.pass=newpassword
 admin.user=admin
 admin.pass=newpassword
-node.db.config.main.host=<Replace with jdbc-url>
+node.db.config.main.host=myDBHost.com
 node.db.config.main.port=3306
 node.db.config.main.name=ssg
 node.db.config.main.user=gateway
@@ -1184,6 +1184,7 @@ node.cluster.pass=newpassword
 admin.user=admin
 admin.pass=newpassword
 node.db.type=derby
+node.db.config.main.user=gateway
 ```
 
 - Mounting a pre-configured node.properties to container gateway

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1189,15 +1189,18 @@ node.db.config.main.user=gateway
 
 - Mounting a pre-configured node.properties to container gateway
 
+values.yaml
+
 ```
 disklessConfig:
-  enabled: true
+  enabled: false
   value:
   # existingSecretName:
 ```
+
 - Use set file to place a node.properties here
  ```
-helm install my-ssg --set "disklessConfig.enabled=true" --set-file "disklessConfig.value=path/to/node.properties"  --set-file "license.value=license.value=path/to/license.xml" --set "license.accept=true"layer7/gateway  ./values.yaml
+helm install my-ssg --set "disklessConfig.enabled=true" --set-file "disklessConfig.value=path/to/node.properties"  --set-file "license.value=path/to/license.xml" --set "license.accept=true" layer7/gateway  ./values.yaml
  ```
 
 ### Bundle Configuration

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -440,7 +440,7 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `global.schedulerName`                      | Override the default scheduler | `nil` |
 | `license.value`          | Gateway license file | `nil`  |
 | `license.accept`          | Accept Gateway license EULA | `false`  |
-| `disklessConfig`          | Boolean value whether to use diskless configuration for Gateway or not. When true, environment variables are used to configure Gateway. When false, node.properties is used. | `true` |
+| `disklessConfig`          | [Refer to techdocs](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-gateway/congw11-1/install-configure-upgrade/configuring-the-container-gateway/environment-variables-for-the-container-gateway.html.)|
 | `image.registry`    | Image Registry               | `docker.io` |
 | `image.repository`          | Image Repository  | `caapim/gateway`  |
 | `image.tag`          | Image tag | `11.0.00`  |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1197,7 +1197,7 @@ disklessConfig:
 ```
 - Use set file to place a node.properties here
  ```
-helm install my-ssg --set-file "license.value=license.value=path/to/license.xml" --set "disklessConfig.enabled=true" --set-file "disklessConfig.value=license.value=path/to/node.properties" --set "license.accept=true"layer7/gateway  ./values.yaml
+helm install my-ssg --set "disklessConfig.enabled=true" --set-file "disklessConfig.value=path/to/node.properties"  --set-file "license.value=license.value=path/to/license.xml" --set "license.accept=true"layer7/gateway  ./values.yaml
  ```
 
 ### Bundle Configuration

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -11,7 +11,7 @@ license:
 
 disklessConfig:
   enabled: true
-  value:
+  # value:
   # existingSecretName:
 
 image:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -9,7 +9,10 @@ license:
   accept: false
   # existingSecretName: ssg-license
 
-disklessConfig: true
+disklessConfig:
+  enabled: true
+  value:
+  # existingSecretName:
 
 image:
   registry: docker.io

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -9,6 +9,8 @@ license:
   accept: false
   # existingSecretName: ssg-license
 
+disklessConfig: true
+
 image:
   registry: docker.io
   repository: caapim/gateway

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -196,9 +196,9 @@ Define OTK Image Pull Secret Name
 {{/*
  Define Gateway node.properties Secret Name
  */}}
-{{- define "nodePropertiesSecretName" -}}
-{{- if .Values.nodePropertiesExistingSecretName -}}
-    {{ .Values.nodePropertiesExistingSecretName }}
+{{- define "gateway.node.properties" -}}
+{{- if .Values.disklessConfig.existingSecretName -}}
+    {{ .Values.disklessConfig.existingSecretName }}
 {{- else -}}
     {{- printf "%s-%s" (include "gateway.fullname" .) "node.properties" -}}
 {{- end -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -194,6 +194,17 @@ Define OTK Image Pull Secret Name
 {{- end -}}
 
 {{/*
+ Define Gateway node.properties Secret Name
+ */}}
+{{- define "nodePropertiesSecretName" -}}
+{{- if .Values.nodePropertiesExistingSecretName -}}
+    {{ .Values.nodePropertiesExistingSecretName }}
+{{- else -}}
+    {{- printf "%s-%s" (include "gateway.fullname" .) "node.properties" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
  Validate OTK installation type (SINGLE, INTERNAL, DMZ)
 */}}
 {{- define "otk-install-type" -}}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -18,7 +18,7 @@ metadata:
 {{- end }}
 data:
   ACCEPT_LICENSE: {{ .Values.license.accept | quote}}
-  DISKLESS_CONFIG: {{ .Values.disklessConfig | quote }}
+  DISKLESS_CONFIG: {{ .Values.disklessConfig.enabled | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
 {{- if .Values.disklessConfig }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -22,10 +22,12 @@ data:
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
 {{- if .Values.database.enabled }}
-  {{- if .Values.database.create }}
+  {{- if .Values.disklessConfig }}
+    {{- if .Values.database.create }}
   SSG_DATABASE_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.database.name }}
-  {{- else }}
+    {{- else }}
   SSG_DATABASE_JDBC_URL: {{ .Values.database.jdbcURL }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -18,6 +18,7 @@ metadata:
 {{- end }}
 data:
   ACCEPT_LICENSE: {{ .Values.license.accept | quote}}
+  DISKLESS_CONFIG: {{ .Values.disklessConfig | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
 {{- if .Values.database.enabled }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
   DISKLESS_CONFIG: {{ .Values.disklessConfig.enabled | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
-{{- if .Values.disklessConfig }}
+{{- if .Values.disklessConfig.enabled }}
   {{- if .Values.database.enabled }}
     {{- if .Values.database.create }}
   SSG_DATABASE_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.database.name }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -21,8 +21,8 @@ data:
   DISKLESS_CONFIG: {{ .Values.disklessConfig | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
-{{- if .Values.database.enabled }}
-  {{- if .Values.disklessConfig }}
+{{- if .Values.disklessConfig }}
+  {{- if .Values.database.enabled }}
     {{- if .Values.database.create }}
   SSG_DATABASE_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.database.name }}
     {{- else }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -468,28 +468,20 @@ spec:
             items:
             - key: license
               path: license.xml
-  {{ - if not .Values.disklessConfig.enabled }}
+  {{- if not .Values.disklessConfig.enabled }}
       - name: {{ template "gateway.fullname" . }}-node-properties
         secret:
           secretName: {{ template "gateway.node.properties" . }}
           items:
             - key: node.properties
               path: node.properties
-  {{ - end }}
+  {{- end }}
         - name: {{ template "gateway.fullname" . }}-system-properties
           configMap:
             name: {{ template "gateway.fullname" . }}-configmap
             items:
             - key: system-properties
               path: system.properties
-{{- if not .Values.disklessConfig }}
-        - name: {{ template "gateway.fullname" . }}-node-properties
-          secret:
-            secretName: {{ template "nodePropertiesSecretName" . }}
-            items:
-            - key: node.properties
-              path: node.properties
-{{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}
         - name: {{ template "gateway.fullname" . }}-hazelcast-client
           configMap:

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -192,6 +192,11 @@ spec:
             - name: {{ template "gateway.fullname" . }}-system-properties
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/system.properties
               subPath: system.properties
+{{- if not .Values.disklessConfig }}
+            - name: {{ template "gateway.fullname" . }}-node-properties
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
+              subPath: node.properties
+{{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}
             - name: {{ template "gateway.fullname" . }}-hazelcast-client
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/assertions/ExternalHazelcastSharedStateProviderAssertion/hazelcast-client.xml
@@ -469,6 +474,14 @@ spec:
             items:
             - key: system-properties
               path: system.properties
+{{- if not .Values.disklessConfig }}
+        - name: {{ template "gateway.fullname" . }}-node-properties
+          secret:
+            secretName: {{ template "nodePropertiesSecretName" . }}
+            items:
+            - key: node.properties
+              path: node.properties
+{{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}
         - name: {{ template "gateway.fullname" . }}-hazelcast-client
           configMap:

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -469,10 +469,10 @@ spec:
             - key: license
               path: license.xml
   {{- if not .Values.disklessConfig.enabled }}
-      - name: {{ template "gateway.fullname" . }}-node-properties
-        secret:
-          secretName: {{ template "gateway.node.properties" . }}
-          items:
+        - name: {{ template "gateway.fullname" . }}-node-properties
+          secret:
+            secretName: {{ template "gateway.node.properties" . }}
+            items:
             - key: node.properties
               path: node.properties
   {{- end }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -192,7 +192,7 @@ spec:
             - name: {{ template "gateway.fullname" . }}-system-properties
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/system.properties
               subPath: system.properties
-{{- if not .Values.disklessConfig }}
+{{- if not (.Values.disklessConfig.enabled) }}
             - name: {{ template "gateway.fullname" . }}-node-properties
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
               subPath: node.properties
@@ -468,6 +468,14 @@ spec:
             items:
             - key: license
               path: license.xml
+  {{ - if not .Values.disklessConfig.enabled }}
+      - name: {{ template "gateway.fullname" . }}-node-properties
+        secret:
+          secretName: {{ template "gateway.node.properties" . }}
+          items:
+            - key: node.properties
+              path: node.properties
+  {{ - end }}
         - name: {{ template "gateway.fullname" . }}-system-properties
           configMap:
             name: {{ template "gateway.fullname" . }}-configmap

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,8 +1,8 @@
-{{ if not .Values.disklessConfig }}
-  {{ if not .Values.nodePropertiesExistingSecretName }}
+{{ if not .Values.disklessConfig.enabled }}
+{{ if not .Values.disklessConfig.existingSecretName }}
 kind: Secret
 metadata:
-  name:  {{ template "nodePropertiesSecretName" . }}
+  name:  {{ template "gateway.node.properties" . }}
   annotations:
     description: Template for Secrets for Gateway node.properties
   labels:
@@ -12,6 +12,6 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
-  node.properties: {{ .Files.Get "node.properties" | b64enc }}
-  {{ end }}
+  node.properties: {{ required "Please provide a Layer7 Gateway node.properties, as disklessConfig flag is false" .Values.disklessConfig.value | b64enc | quote }}
+{{ end }}
 {{ end }}

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,0 +1,17 @@
+{{ if not .Values.disklessConfig }}
+  {{ if not .Values.nodePropertiesExistingSecretName }}
+kind: Secret
+metadata:
+  name:  {{ template "nodePropertiesSecretName" . }}
+  annotations:
+    description: Template for Secrets for Gateway node.properties
+  labels:
+    app: {{ template "gateway.name" . }}
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  node.properties: {{ .Files.Get "node.properties" | b64enc }}
+  {{ end }}
+{{ end }}

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,5 +1,6 @@
 {{ if not .Values.disklessConfig.enabled }}
-{{ if not .Values.disklessConfig.existingSecretName }}
+  {{ if not .Values.disklessConfig.existingSecretName }}
+apiVersion: v1
 kind: Secret
 metadata:
   name:  {{ template "gateway.node.properties" . }}
@@ -13,5 +14,5 @@ metadata:
 type: Opaque
 data:
   node.properties: {{ required "Please provide a Layer7 Gateway node.properties, as disklessConfig flag is false" .Values.disklessConfig.value | b64enc | quote }}
-{{ end }}
+  {{ end }}
 {{ end }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -21,13 +21,15 @@ metadata:
 {{- end }}
 type: Opaque
 data:
+{{- if .Values.disklessConfig }}
   SSG_ADMIN_USERNAME: {{ .Values.management.username | b64enc }}
   SSG_ADMIN_PASSWORD: {{ .Values.management.password | b64enc }}
   SSG_CLUSTER_PASSWORD: {{.Values.clusterPassword | b64enc }}
-{{ if .Values.database.enabled }}
+  {{ if .Values.database.enabled }}
   SSG_DATABASE_USER: {{.Values.database.username | b64enc }}
   SSG_DATABASE_PASSWORD:  {{.Values.database.password | b64enc }}
-{{ end }}
+  {{ end }}
+{{- end }}
 {{ if .Values.additionalSecret }}
 {{- range $key, $val := .Values.additionalSecret }}
   {{ $key }}: {{ $val | toString | b64enc }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -21,7 +21,7 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-{{- if .Values.disklessConfig }}
+{{- if .Values.disklessConfig.enabled }}
   SSG_ADMIN_USERNAME: {{ .Values.management.username | b64enc }}
   SSG_ADMIN_PASSWORD: {{ .Values.management.password | b64enc }}
   SSG_CLUSTER_PASSWORD: {{.Values.clusterPassword | b64enc }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -9,7 +9,12 @@ license:
   accept: false
   # existingSecretName: ssg-license
 
-disklessConfig: true
+# Use set diskless Configuration mode for Gateway
+# when true , get values from environment variable and on false will get values from node.properties
+disklessConfig:
+  enabled: true
+  value:
+  # existingSecretName:
 
 image:
   registry: docker.io

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -11,9 +11,10 @@ license:
 
 # Use set diskless Configuration mode for Gateway
 # when true , get values from environment variable and on false will get values from node.properties
+# when disklessConfig.enabled is false , node.properties is passed via disklessConfig.value parameter
 disklessConfig:
   enabled: true
-  value:
+  # value:
   # existingSecretName:
 
 image:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -9,6 +9,8 @@ license:
   accept: false
   # existingSecretName: ssg-license
 
+disklessConfig: true
+
 image:
   registry: docker.io
   repository: caapim/gateway


### PR DESCRIPTION
**Description of the change**

(Dependent on newer version of container gateway that will process DISKLESS_CONFIG property)

Introduce disklessConfig property to configmap.yaml to pass DISKLESS_CONFIG environment variable to Gateway container.

TODO: 
1. Update logic in templates - Set environment variables only when DISKLESS_CONFIG is true
  - Needed; database section: when DISKLESS_CONFIG is true and create is false, database.jdbcURL can be empty because it will be constructed from node.properties values
    - Need to fix because jdbcURL is commented out by default so right now user has to supply dummy value to prevent Kubernetes validation error:
      ```
      Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: unknown object type "nil" in ConfigMap.data.SSG_DATABASE_JDBC_URL
      ```
    - Addressed by https://github.com/CAAPIM/apim-charts/pull/318/commits/4346f7fdfab12752203ce0bb348d78d43fa4548e -
    - When DISKLESS_CONFIG is false, database.jdbcURL can now be empty and SSG_DATABASE_JDBC_URL is not set
    - When DISKLESS_CONFIG is true, SSG_DATABASE_JDBC_URL is set
  - Optional: other variables below that can be empty because they're in node.properties
    - clusterPassword - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - database.username - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - database.password - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - database.name - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - management.username - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - management.password - Optional to fix because default is non-empty, but value will be ignored when DISKLESS_CONFIG is true
    - Addressed by https://github.com/CAAPIM/apim-charts/pull/318/commits/27ef8bb2c87764b3d408cb99f9c5559d2e87e687 (database.name covered by https://github.com/CAAPIM/apim-charts/pull/318/commits/4346f7fdfab12752203ce0bb348d78d43fa4548e)
    - When DISKLESS_CONFIG is false, above properties can now be empty and corresponding environment variables are not set
    - When DISKLESS_CONFIG is true, corresponding environment variables are set
2. Describe node.properties and how to set it up - b2e9a530e4df19f73d1211003157493638647215
  - How do we want to document the secret creation? 
     1. node.properties can be passed using set-file , similar to license.xml
     2. Node.properties secret will be created if existingSecretName is not set
4. Put some doc regarding diskless config on techdocs. Doc in this repo to focus more on usage.
  - Add link to techdocs from here 
  - Added a note on Readme : 996efe05f18ad3c030afe81b09bb009a51c8a15e

**Benefits**

As this is a required environment variable, it's better for visibility and more appropriate to have its own property, as the way Gateway is configured is very different depending on the value.

Existing way to set DISKLESS_CONFIG is via additionalEnv, but I feel this is for more optional variables, not for an integral setting for Gateway configuration:
```
additionalEnv:
  DISKLESS_CONFIG: false
```

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

