### PR TITLE
[charts/gateway] DE606668 Helm chart otk Installation failing with error 

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -101,7 +101,6 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
 - Liquibase version has been upgraded to 4.12.0 to enable offline Liquibase schema support for OTK Helm charts.
 - UTFMB4 Character Set Support for MySQL.
 - Fixed backward compatibility issue related to bootstrap director location for pre 4.6.2 OTK versions
-  - The default value for versions OTK 4.6.2 & higher is /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
   - For versions older than OTK 4.6.2, in values.yaml manually add a new parameter otk.bootstrapDir with value "." indicating current directory
 
 ## 3.0.28 General Updates
@@ -662,7 +661,7 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.job.resources`               | OTK Job resources | {}
 | `otk.job.scheduledTasksSuccessfulJobsHistoryLimit`| OTK db maintenance scheduled job success history limit | `1` |
 | `otk.job.scheduledTasksFailedJobsHistoryLimit`| OTK db maintenance scheduled job failed history limit | `1` |
-| `otk.job.bootstrapDir`| The location of OTK artifacts in the image | `/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK` |
+| `otk.bootstrapDir`| The location of OTK artifacts in the image | `/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK` |
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -100,6 +100,7 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
     - otk.job.image.tag: 4.6.3
 - Liquibase version has been upgraded to 4.12.0 to enable offline Liquibase schema support for OTK Helm charts.
 - UTFMB4 Character Set Support for MySQL.
+- Fixed backward compatibility issue for pre 4.6.2 OTK versions
 
 ## 3.0.28 General Updates
 - Added a [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Gateway Container.

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -659,6 +659,7 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.job.resources`               | OTK Job resources | {}
 | `otk.job.scheduledTasksSuccessfulJobsHistoryLimit`| OTK db maintenance scheduled job success history limit | `1` |
 | `otk.job.scheduledTasksFailedJobsHistoryLimit`| OTK db maintenance scheduled job failed history limit | `1` |
+| `otk.job.bootstrapDir`| The location of OTK artifacts in the image | `/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK` |
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -100,7 +100,9 @@ Things to note and be aware of are the deprecation of TLSv1.0/TLSv1.1 and the JA
     - otk.job.image.tag: 4.6.3
 - Liquibase version has been upgraded to 4.12.0 to enable offline Liquibase schema support for OTK Helm charts.
 - UTFMB4 Character Set Support for MySQL.
-- Fixed backward compatibility issue for pre 4.6.2 OTK versions
+- Fixed backward compatibility issue related to bootstrap director location for pre 4.6.2 OTK versions
+  - The default value for versions OTK 4.6.2 & higher is /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
+  - For versions older than OTK 4.6.2, in values.yaml manually add a new parameter otk.bootstrapDir with value "." indicating current directory
 
 ## 3.0.28 General Updates
 - Added a [Startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) for the Gateway Container.

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -667,6 +667,8 @@ otk:
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false
+    # The default value set below is for OTK 4.6.2. For the older versions, this value should be set as "." indicating current directory
+    bootstrapDir : /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
 
     # Valid only for ephemeral gateway. Creates cronJobs for each OTK DB maintenance schedule tasks.
     scheduledTasks:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -667,9 +667,6 @@ otk:
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false
-    # The default value set below is for OTK 4.6.2. For the older versions, this value should be set as "." indicating current directory
-    bootstrapDir : /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
-
     # Valid only for ephemeral gateway. Creates cronJobs for each OTK DB maintenance schedule tasks.
     scheduledTasks:
       - name: client

--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -24,7 +24,7 @@ data:
   {{- else }}
   OTK_INSTALL_MODE: "initContainer"
   {{- end }}
-  BOOTSTRAP_DIR: {{default "." .Values.otk.bootstrapDir | quote }}
+  BOOTSTRAP_DIR: {{default "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK" .Values.otk.bootstrapDir | quote }}
   OTK_SK_UPGRADE: "true"
   OTK_DATABASE_UPGRADE: "false"
   OTK_SKIP_INTERNAL_SERVER_TOOLS: {{default false .Values.otk.skipInternalServerTools | quote }}

--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -24,7 +24,7 @@ data:
   {{- else }}
   OTK_INSTALL_MODE: "initContainer"
   {{- end }}
-  BOOTSTRAP_DIR: "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK"
+  BOOTSTRAP_DIR: {{default "." .Values.otk.bootstrapDir | quote }}
   OTK_SK_UPGRADE: "true"
   OTK_DATABASE_UPGRADE: "false"
   OTK_SKIP_INTERNAL_SERVER_TOOLS: {{default false .Values.otk.skipInternalServerTools | quote }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -667,9 +667,6 @@ otk:
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false
-    # The default value set below is for OTK 4.6.2. For the older versions, this value should be set as "." indicating current directory
-    bootstrapDir : /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
-
     # Valid only for ephemeral gateway. Creates cronJobs for each OTK DB maintenance schedule tasks.
     scheduledTasks:
       - name: client

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -669,6 +669,7 @@ otk:
       enabled: false
     # The default value set below is for OTK 4.6.2. For the older versions, this value should be set as "." indicating current directory
     bootstrapDir : /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
+
     # Valid only for ephemeral gateway. Creates cronJobs for each OTK DB maintenance schedule tasks.
     scheduledTasks:
       - name: client

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -667,7 +667,8 @@ otk:
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false
-
+    # The default value set below is for OTK 4.6.2. For the older versions, this value should be set as "." indicating current directory
+    bootstrapDir : /opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/000OTK
     # Valid only for ephemeral gateway. Creates cronJobs for each OTK DB maintenance schedule tasks.
     scheduledTasks:
       - name: client


### PR DESCRIPTION
**Description of the change**

fixing issue to provide backward compatibility to install 4.6 from newer chart versions

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #DE606668

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

