### PR TITLE
[charts/portal] NORALLY: disable ngnix status access for controller

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.3"
 description: CA API Developer Portal
 name: portal
-version: 2.4.1
+version: 2.4.2
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -911,6 +911,8 @@ ingress-nginx:
     config:
       # 30MB is the max file size we allow for the custom pages and 15MB for GW Bundle.so max is set to 32
       proxy-body-size: "32m"
+      # disable external access to nginx-status
+      nginx-status-ipv4-whitelist: ""
     publishService:
       enabled: true
     extraArgs:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -766,6 +766,8 @@ ingress-nginx:
     config:
       # 30MB is the max file size we allow for the custom pages and 15MB for GW Bundle.so max is set to 32
       proxy-body-size: "32m"
+      # disable external access to nginx-status
+      nginx-status-ipv4-whitelist: ""
     publishService:
       enabled: true
     extraArgs:


### PR DESCRIPTION
**Description of the change**

Disable ingress-nginx external status access 

**Benefits**

Security enhancement

**Drawbacks**

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes DE594378

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

