### PR TITLE
[charts/gateway] otel update, system properties expansion, ocp routes

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.1.1"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.30
+version: 3.0.31
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -186,6 +186,24 @@ config:
   # If you are using an earlier version of the Gateway, these will be ignored.
   # minHeapSize: "1g"
   # maxHeapSize: "3g"
+  # The OTel SDK uses the following environment variables to gather information about the container
+  # NODE_NAME - Kubernetes Node
+  # POD_NAME - Podname, also hostname
+  # NAMESPACE
+  # CONTAINER_NAME - this is always gateway
+  # OTEL_SERVICE_NAME - <release-name>-<chart-name>
+  # OTEL_RESOURCE_ATTRIBUTES
+  # When using auto-instrumentation (injecting the OTel Java Agent via the OpenTelemetryOperator) these values are automatically set
+  # When using the sdk only approach (no OTel Java Agent) we set these using built-in metadata fields
+  otel:
+    # If sdkOnly is enabled we will inject the above environment variables
+    # Note that this is container level configuration only. You will still need to set the relevant cluster-wide and system properties below
+    sdkOnly:
+      enabled: false
+    # Used to inject additional resource attributes for tracking with the sdkOnly approach
+    additionalResourceAttributes: []
+    # - test=someEnvValue
+    # - test1=someEnvValue1
   javaArgs:
     - -Dcom.l7tech.bootstrap.autoTrustSslKey=trustAnchor,TrustedFor.SSL,TrustedFor.SAML_ISSUER
     - -Dcom.l7tech.server.audit.message.saveToInternal=false
@@ -268,13 +286,17 @@ config:
     # If you would like to use the built in OpenTelemetry SDK uncomment and set the following configuration
     # otel.sdk.disabled=false
     # otel.java.global-autoconfigure.enabled=true
-    # otel.service.name=ssg-gateway
     # otel.exporter.otlp.endpoint=http://localhost:4318/
     # otel.exporter.otlp.protocol=http/protobuf
     # otel.traces.exporter=otlp
     # otel.metrics.exporter=otlp
     # otel.logs.exporter=none
     # Additional properties go here
+  # Additional System properties are appended at the end of system.properties
+  # Defined as key/value pairs
+  additionalSystemProperties: []
+  # - name: test
+  #   value: test123
 
  # If enabled this will override the default listen ports and their configuration in the API Gateway
   listenPorts:
@@ -885,17 +907,19 @@ otk:
 ingress:
   # Set to true to create ingress object
   enabled: true
+  # Set openshift.route.enabled to true if you are using Openshift and would like to use routes
+  openshift:
+    route:
+      enabled: false
+      wildcardPolicy: None
+    # weight: 100
   # Ingress Class Name
   ingressClassName: nginx
   # Ingress annotations
   annotations:
-  # Ingress class
-   # kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   # When the ingress is enabled, a host pointing to this will be created
-  # By default clusterHostname is used, only set this if you want to use a different host
-   ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
   tls:
   - hosts:
     - dev.ca.com
@@ -903,7 +927,6 @@ ingress:
   # - hosts:
   #   - dev1.ca.com
   #   secretName: default
-
   rules:
   - host: dev.ca.com
     path: "/"
@@ -911,13 +934,19 @@ ingress:
       port:
         name: https
       # number:
-  #  - host: dev1.ca.com
-  #    path: "/"
-  #    backend: management
-  #    service:
-  #      port:
-  #        name: management
-  #        #number:
+  # - host: dev1.ca.com
+  #   path: "/"
+  #   service:
+  #     port:
+  #       name: https
+      # number:
+  # - host: dev-pm.ca.com
+  #   path: "/"
+  #   backend: management
+  #   service:
+  #     port:
+  #       name: management
+        # number:
 
 # Additional Environment variables to be added to the Gateway Configmap
 additionalEnv: {}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -203,6 +203,21 @@ Define OTK Image Pull Secret Name
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+ Define OTEL_RESOURCE_ATTRIBUTES Environment variable
+ */}}
+{{- define "gateway.otel.resource.attributes" -}}
+{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" .Values.image.tag }}
+{{- if and (.Values.config.otel.sdkOnly.enabled) (.Values.config.otel.additionalResourceAttributes) -}}
+ {{- $additionalResourceAttributes := join "," .Values.config.otel.additionalResourceAttributes }}
+ {{- printf "%s,%s" $resourceAttributes $additionalResourceAttributes -}}
+{{- else -}}
+    {{- printf "%s" $resourceAttributes -}}
+{{- end -}}
+{{- end -}}
+
+
 {{/*
  Validate OTK installation type (SINGLE, INTERNAL, DMZ)
 */}}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -93,6 +93,11 @@ data:
   system-properties: |-
 {{ .Values.config.systemProperties | indent 4 }}
 {{- end }}
+{{- if .Values.config.additionalSystemProperties }}
+{{- range .Values.config.additionalSystemProperties }}
+    {{ .name }}={{ .value }}
+{{- end }}
+{{- end }}
 {{- if .Values.management.kubernetes.loadServiceAccountToken }}
   002-load-service-account-token: |-
     #!/bin/bash

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -354,6 +354,27 @@ spec:
          {{- end }}
          {{- end }}
 {{- end }}
+         {{- if .Values.config.otel.sdkOnly.enabled }}
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CONTAINER_NAME
+            value: gateway
+          - name: OTEL_SERVICE_NAME
+            value: {{ template "gateway.fullname" . }}
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: {{ template "gateway.otel.resource.attributes" . }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "gateway.fullname" . }}-configmap

--- a/charts/gateway/templates/ingress.yaml
+++ b/charts/gateway/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.ingress.enabled }}
+{{ if and (.Values.ingress.enabled) (not .Values.ingress.openshift.route.enabled) }}
 {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
@@ -12,6 +12,9 @@ metadata:
    release: {{ .Release.Name }}
    heritage: {{ .Release.Service }}
    {{- range $key, $val := .Values.additionalLabels }}
+   {{ $key }}: "{{ $val }}"
+   {{- end }}
+   {{- range $key, $val := .Values.ingress.labels }}
    {{ $key }}: "{{ $val }}"
    {{- end }}
  annotations:

--- a/charts/gateway/templates/route.yaml
+++ b/charts/gateway/templates/route.yaml
@@ -1,0 +1,53 @@
+{{ if and (.Values.ingress.enabled) (.Values.ingress.openshift.route.enabled) }}
+{{- $gatewayFullName := include "gateway.fullname" . }}
+{{- range $i,$rule := .Values.ingress.rules }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $.Release.Name }}-{{ $.Chart.Name }}-route-{{ $i }}
+  labels:
+    release: {{ $.Release.Name }}-{{ $.Chart.Name }}
+    heritage: {{ $.Release.Service }}
+    {{- range $key, $val := $.Values.ingress.labels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- range $key, $val := $.Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+{{- if $.Values.ingress.annotations }}
+  annotations:
+{{- range $key, $val := $.Values.ingress.annotations }}
+   {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
+spec:
+  host: {{ .host }}
+  port:
+{{- if .service.port.name  }}
+    targetPort: {{ .service.port.name }}
+{{- else }}
+    targetPort: {{ default 8443 .service.port.number }}
+{{- end }}
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+{{- if .backend }}
+{{- if eq .backend "management" }}
+    name: {{ $gatewayFullName }}-management
+{{- else }}
+    name: {{ $gatewayFullName }}
+{{- end }}
+{{- else }}
+    name: {{ $gatewayFullName }}
+{{- end }}
+{{- if $.Values.ingress.openshift.route.weight }}
+    weight: {{ default 100 $.Values.ingress.openshift.route.weight }}
+{{- end }}
+{{- if $.Values.ingress.openshift.route.wildcardPolicy }}
+  wildcardPolicy: {{ default "None" $.Values.ingress.openshift.route.wildcardPolicy }}
+{{- end }}
+---
+{{- end }}
+{{ end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -186,6 +186,24 @@ config:
   # If you are using an earlier version of the Gateway, these will be ignored.
   # minHeapSize: "1g"
   # maxHeapSize: "3g"
+  # The OTel SDK uses the following environment variables to gather information about the container
+  # NODE_NAME - Kubernetes Node
+  # POD_NAME - Podname, also hostname
+  # NAMESPACE
+  # CONTAINER_NAME - this is always gateway
+  # OTEL_SERVICE_NAME - <release-name>-<chart-name>
+  # OTEL_RESOURCE_ATTRIBUTES
+  # When using auto-instrumentation (injecting the OTel Java Agent via the OpenTelemetryOperator) these values are automatically set
+  # When using the sdk only approach (no OTel Java Agent) we set these using built-in metadata fields
+  otel:
+    # If sdkOnly is enabled we will inject the above environment variables
+    # Note that this is container level configuration only. You will still need to set the relevant cluster-wide and system properties below
+    sdkOnly:
+      enabled: false
+    # Used to inject additional resource attributes for tracking with the sdkOnly approach
+    additionalResourceAttributes: []
+    # - test=someEnvValue
+    # - test1=someEnvValue1
   javaArgs:
     - -Dcom.l7tech.bootstrap.autoTrustSslKey=trustAnchor,TrustedFor.SSL,TrustedFor.SAML_ISSUER
     - -Dcom.l7tech.server.audit.message.saveToInternal=false
@@ -268,13 +286,17 @@ config:
     # If you would like to use the built in OpenTelemetry SDK uncomment and set the following configuration
     # otel.sdk.disabled=false
     # otel.java.global-autoconfigure.enabled=true
-    # otel.service.name=ssg-gateway
     # otel.exporter.otlp.endpoint=http://localhost:4318/
     # otel.exporter.otlp.protocol=http/protobuf
     # otel.traces.exporter=otlp
     # otel.metrics.exporter=otlp
     # otel.logs.exporter=none
     # Additional properties go here
+  # Additional System properties are appended at the end of system.properties
+  # Defined as key/value pairs
+  additionalSystemProperties: []
+  # - name: test
+  #   value: test123
 
  # If enabled this will override the default listen ports and their configuration in the API Gateway
   listenPorts:
@@ -885,17 +907,22 @@ otk:
 ingress:
   # Set to true to create ingress object
   enabled: false
+  # Set openshift.route.enabled to true if you are using Openshift and would like to use routes
+  openshift:
+    route:
+      enabled: false
+      wildcardPolicy: None
+    # weight: 100
+
   # Ingress Class Name
   ingressClassName: nginx
-  # Ingress annotations
+  # Ingress labels (also apply to routes)
+  labels: {}
+  # Ingress annotations (also apply to routes)
   annotations: {}
-  # Ingress class
-   # kubernetes.io/ingress.class: nginx
   # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   # nginx.ingress.kubernetes.io/ssl-passthrough: "true"
   # When the ingress is enabled, a host pointing to this will be created
-  # By default clusterHostname is used, only set this if you want to use a different host
-   ## Enable TLS configuration for the hostname defined at ingress.hostname/clusterHostname parameter
   tls:
   - hosts:
     - dev.ca.com
@@ -903,7 +930,6 @@ ingress:
   # - hosts:
   #   - dev1.ca.com
   #   secretName: default
-
   rules:
   - host: dev.ca.com
     path: "/"
@@ -911,13 +937,19 @@ ingress:
       port:
         name: https
       # number:
-  #  - host: dev1.ca.com
-  #    path: "/"
-  #    backend: management
-  #    service:
-  #      port:
-  #        name: management
-  #        #number:
+  # - host: dev1.ca.com
+  #   path: "/"
+  #   service:
+  #     port:
+  #       name: https
+      # number:
+  # - host: dev-pm.ca.com
+  #   path: "/"
+  #   backend: management
+  #   service:
+  #     port:
+  #       name: management
+        # number:
 
 # Additional Environment variables to be added to the Gateway Configmap
 additionalEnv: {}


### PR DESCRIPTION
**Description of the change**
## 3.0.31 General Updates
- Support for Openshift Routes (disabled by default)
  - Uses passthrough termination (tls only)
    - path is ignored in this mode
  - Converts existing ingress
    - will create a route for each ingress rule
  - Management service can be routed

To enable - see [ingress configuration](./README.md#ingress-configuration) for more details
```
ingress:
  enabled: true
  openshift:
    route:
      enabled: true
      wildcardPolicy: None
    # weight: 100
  ...
  rules:
  - host: dev.ca.com
    path: "/"
    service:
      port:
        name: https
  - host: dev1.ca.com
    path: "/"
    service:
      port:
        name: https
  - host: dev-pm.ca.com
    path: "/"
    backend: management
    service:
      port:
        name: management
```

- New way to add system properties
  - You can now use key/value pairs to extend [system properties](./README.md#system-properties)
  - No impact to existing configuration
```
config:
  ...
  additionalSystemProperties:
  - name: test
    value: test123
```
- New Deployment Configuration Options for the OTel SDK Only approach (Disabled by default)
  - Does ***NOT*** configure system or cluster-wide properties, this step is still required
  - Requires a Gateway restart when enabled
  - injects the following environment variables which are then used to set OTEL_RESOURCE_ATTRIBUTES
    - NODE_NAME      ==> spec.nodeName
    - POD_NAME       ==> metadata.name
    - NAMESPACE      ==> metadata.namespace 
    - CONTAINER_NAME ==> gateway
    - OTEL_SERVICE_NAME - `<release-name>-<chart-name>`
    - OTEL_RESOURCE_ATTRIBUTES ==> custom values can be set with config.otel.additionalResourceAttributes
      - defaults (if config.otel.sdkOnly.enabled is true)
        - service.name         ==> OTEL_SERVICE_NAME
        - service.version      ==> .Values.image.tag
        - k8s.container.name   ==> gateway
        - k8s.deployment.name  ==> OTEL_SERVICE_NAME
        - k8s.namespace.name   ==> NAMESPACE
        - k8s.node.name        ==> NODE_NAME
        - k8s.pod.name         ==> POD_NAME
```
config:
...
  otel:
    sdkOnly:
      enabled: true
    # Used to inject additional resource attributes for tracking with the sdkOnly approach
    additionalResourceAttributes:
    - test=someEnvValue
    - test1=someEnvValue1
```

**Benefits**
- Improved support for SDK Only OTel integration
- Simpler system property configuration
- Easier to use in Openshift

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

