### PR TITLE
[charts/gateway] U1002015 OTK Helm changes

### DIFF
--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -861,6 +861,21 @@ otk:
       # Oracle database name
       databaseName:
 
+    # Optionally configure Client read database connection for MySQL/Oracle.
+    clientReadConnection:
+      enabled: false
+      # connectionName: Oauth_Client_Read
+      # existingSecretName: otkClientReadSecret
+      # username: root
+      # password: 7layer
+      # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
+      # connectionProperties: {"c3p0.maxConnectionAge":"100","c3p0.maxIdleTime":"1000"}
+
+      jdbcURL: jdbc:mysql://<host>:<port>/<database>
+      jdbcDriverClass: com.mysql.jdbc.Driver
+      # Oracle database name
+      databaseName:
+
   # Install OTK Health check bundle on gateway. Uses config map.
   # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
   # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otk-healthcheck.bundle

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -268,6 +268,18 @@ Define OTK Image Pull Secret Name
     {{- printf "%s-%s" (include "gateway.fullname" .) "rconn-otkdb-secret" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+ Define OTK database Client Read Connection Secret Name
+ */}}
+{{- define "otk.dbSecretName.clientRead" -}}
+{{- if .Values.otk.database.clientReadConnection.existingSecretName -}}
+    {{ .Values.otk.database.clientReadConnection.existingSecretName }}
+{{- else -}}
+    {{- printf "%s-%s" (include "gateway.fullname" .) "crconn-otkdb-secret" -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
  Define OTK install image pullSecret
  */}}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
         - secretRef:
             name: {{ template "otk.dbSecretName.readOnly" . }}
       {{- end }}
+      {{- if and (.Values.otk.database.clientReadConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+        - secretRef:
+            name: {{ template "otk.dbSecretName.clientRead" . }}
+      {{- end }}
         - configMapRef:
             name: {{ template "gateway.fullname" . }}-otk-install-configmap
         volumeMounts:

--- a/charts/gateway/templates/otk-db-scripts-configmap.yaml
+++ b/charts/gateway/templates/otk-db-scripts-configmap.yaml
@@ -28,5 +28,9 @@ data:
       CREATE USER '{{ .Values.otk.database.readOnlyConnection.username }}'@'%' identified by '{{ .Values.otk.database.readOnlyConnection.password }}';
       GRANT SELECT ON {{ .Values.otk.database.sql.databaseName}}.* TO '{{ .Values.otk.database.readOnlyConnection.username  }}'@'%';
       {{- end }}
+      {{- if  .Values.otk.database.clientReadConnection.enabled }}
+      CREATE USER '{{ .Values.otk.database.clientReadConnection.username }}'@'%' identified by '{{ .Values.otk.database.clientReadConnection.password }}';
+      GRANT SELECT ON {{ .Values.otk.database.sql.databaseName}}.* TO '{{ .Values.otk.database.clientReadConnection.username  }}'@'%';
+      {{- end }}
       flush privileges;
 {{ end }}

--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -49,6 +49,7 @@ data:
   OTK_CREATE_RO_DATABASE_CONN: "false"
   {{- else }}
   OTK_CREATE_RO_DATABASE_CONN: {{default false .Values.otk.database.readOnlyConnection.enabled | quote }}
+  OTK_CREATE_CLIENT_READ_DATABASE_CONN: {{default false .Values.otk.database.clientReadConnection.enabled | quote }}
   {{- end }}
   {{- if eq .Values.otk.database.type "cassandra" }}
   OTK_CASSANDRA_CONNECTION_POINTS: {{ required "Please fill in otk.database.cassandra.connectionPoints in values.yaml" .Values.otk.database.cassandra.connectionPoints | quote }}
@@ -67,12 +68,22 @@ data:
   OTK_RO_DATABASE_PROPERTIES: {{ default "na" .Values.otk.database.readOnlyConnection.properties | toJson | b64enc | quote }}
   OTK_RO_DATABASE_CONN_PROPERTIES: {{ default "na" .Values.otk.database.readOnlyConnection.connectionProperties | toJson | b64enc | quote }}
   {{- end }}
+  {{- if .Values.otk.database.clientReadConnection.enabled }}
+  OTK_CLIENT_READ_DATABASE_CONNECTION_NAME: {{ required "Please fill in otk.database.clientReadConnection.connectionName in values.yaml" .Values.otk.database.clientReadConnection.connectionName | quote }}
+  OTK_CLIENT_READ_JDBC_URL: {{ default .Values.otk.database.sql.jdbcURL .Values.otk.database.clientReadConnection.jdbcURL | quote }}
+  OTK_CLIENT_READ_JDBC_DRIVER_CLASS: {{ default .Values.otk.database.sql.jdbcDriverClass .Values.otk.database.clientReadConnection.jdbcDriverClass | quote }}
+  OTK_CLIENT_READ_DATABASE_PROPERTIES: {{ default "na" .Values.otk.database.clientReadConnection.properties | toJson | b64enc | quote }}
+  OTK_CLIENT_READ_DATABASE_CONN_PROPERTIES: {{ default "na" .Values.otk.database.clientReadConnection.connectionProperties | toJson | b64enc | quote }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.otk.database.type "oracle" }}
   OTK_JDBC_URL: {{ required "Please fill in otk.database.sql.jdbcURL in values.yaml" .Values.otk.database.sql.jdbcURL | quote }}
   OTK_DATABASE_NAME: {{ required "Please fill in otk.database.sql.databaseName in values.yaml" .Values.otk.database.sql.databaseName | quote }}
   {{- if .Values.otk.database.readOnlyConnection.enabled }}
   OTK_RO_DATABASE_NAME: {{ default .Values.otk.database.sql.databaseName .Values.otk.database.readOnlyConnection.databaseName | quote }}
+  {{- end }}
+  {{- if .Values.otk.database.clientReadConnection.enabled }}
+  OTK_CLIENT_READ_DATABASE_NAME: {{ default .Values.otk.database.sql.databaseName .Values.otk.database.clientReadConnection.databaseName | quote }}
   {{- end }}
   {{- end }}
   {{- if eq .Values.otk.database.type "mysql" }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -73,6 +73,10 @@ spec:
             - secretRef:
                 name: {{ template "otk.dbSecretName.readOnly" . }}
             {{ end }}
+            {{- if and (.Values.otk.database.clientReadConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+            - secretRef:
+                name: {{ template "otk.dbSecretName.clientRead" . }}
+            {{ end }}
             - configMapRef:
                 name: {{ template "gateway.fullname" . }}-otk-install-configmap
 

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -861,6 +861,21 @@ otk:
       # Oracle database name
       databaseName:
 
+    # Optionally configure Client read database connection for MySQL/Oracle.
+    clientReadConnection:
+      enabled: false
+      # connectionName: Oauth_Client_Read
+      # existingSecretName: otkClientReadSecret
+      # username: root
+      # password: 7layer
+      # properties: {"maximumPoolSize":15, "minimumPoolSize":3}
+      # connectionProperties: {"c3p0.maxConnectionAge":"100","c3p0.maxIdleTime":"1000"}
+
+      jdbcURL: jdbc:mysql://<host>:<port>/<database>
+      jdbcDriverClass: com.mysql.jdbc.Driver
+      # Oracle database name
+      databaseName:
+
   # Install OTK Health check bundle on gateway. Uses config map.
   # Alternatively the bundle can be loaded using config map external to helm (useExisting: true)
   # The bundle content can be found at https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/bundles/otk-healthcheck.bundle


### PR DESCRIPTION
**Description of the change**

Add client read connection to OTK install process in the script within OTK Helm chart definition

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

