### PR TITLE
[charts/gateway] DE606668 [Internal] Update Helm Documentation

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -377,7 +377,7 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
-| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
+| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `false` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of demo test clients | `false` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  | |
 | `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -377,7 +377,7 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.database.type`               | OTK database type - mysql/oracle/cassandra | `mysql`
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
-| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `false` |
+| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of demo test clients | `false` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  | |
 | `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -797,8 +797,10 @@ otk:
     # OTK database type - mysql/oracle/cassandra
     type: mysql
     connectionName: OAuth
+    # OTK database dbUpgrade - Enable/Disable auto upgrade of OTK MySQL or Oracle DB
     dbUpgrade: true
-    useDemoDb: true
+    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Discouraged for production deployments
+    useDemoDb: false
 
     # OTK database user name and password used to create Gateway Database/cassandra connection.
     username: otk_user

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -799,7 +799,7 @@ otk:
     connectionName: OAuth
     # OTK database dbUpgrade - Enable/Disable auto upgrade of OTK MySQL or Oracle DB
     dbUpgrade: true
-    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Discouraged for production deployments
+    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Do not use this in production deployments.
     useDemoDb: false
 
     # OTK database user name and password used to create Gateway Database/cassandra connection.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -799,7 +799,7 @@ otk:
     connectionName: OAuth
     # OTK database dbUpgrade - Enable/Disable auto upgrade of OTK MySQL or Oracle DB
     dbUpgrade: true
-    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Discouraged for production deployments
+    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Do not use this in production deployments.
     useDemoDb: true
 
     # OTK database user name and password used to create Gateway Database/cassandra connection.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -797,7 +797,9 @@ otk:
     # OTK database type - mysql/oracle/cassandra
     type: mysql
     connectionName: OAuth
+    # OTK database dbUpgrade - Enable/Disable auto upgrade of OTK MySQL or Oracle DB
     dbUpgrade: true
+    # OTK database useDemoDb - install/upgrade OTK DB on the gateways MySQL container for a quick test deployment. Discouraged for production deployments
     useDemoDb: true
 
     # OTK database user name and password used to create Gateway Database/cassandra connection.

--- a/examples/otk/README.md
+++ b/examples/otk/README.md
@@ -67,7 +67,7 @@ Properties related to OTK database install/Upgrade.
 | -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
-| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
+| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `false` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of test clients | `true` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) required for demo test clients  | `true`  |
 | `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|

--- a/examples/otk/README.md
+++ b/examples/otk/README.md
@@ -67,7 +67,7 @@ Properties related to OTK database install/Upgrade.
 | -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
 | `otk.database.waitTimeout`        | OTK database connection wait timeout in seconds  | `60`|
-| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `false` |
+| `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of test clients | `true` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) required for demo test clients  | `true`  |
 | `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|
@@ -121,6 +121,9 @@ For more information please refer to [OTK Release Notes](https://techdocs.broadc
 | `otk.database.clientReadConnection.connectionProperties`| OTK Client Read only  database mysql connection properties (oracle/mysql)  | `{}`
 | `otk.database.clientReadConnection.databaseName` | OTK Client Read only Oracle database name |
 
+
+The Gateways MySQL demo container can be used to install OTK DB by setting `otk.database.useDemoDb` to `true` which is the default setting in values.yaml and this needs to be disabled for production(production-values.yaml).
+
 ```
 otk:
   ....
@@ -140,11 +143,12 @@ otk:
 ....
 .....
 ```
-### Cassandra database  (`otk.database.type:mysql/oracle`) 
+### Cassandra database  (`otk.database.type:cassandra`) 
 > :information_source: **Important** <br>
 > Install or Upgrade of OTK database on Cassandra is not supported.
 
 Configure cassandra connection properties
+
 | Parameter                        | Description                               | Default                                                      |
 | -----------------------------    | -----------------------------------       | -----------------------------------------------------------  |
 | `otk.database.updateConnection`   | Update database connection properties during helm upgrade | `true`|
@@ -155,11 +159,11 @@ Configure cassandra connection properties
 | `otk.database.cassandra.connectionPoints`  | OTK database cassandra connection points (comma seperated)  |
 | `otk.database.cassandra.port`              | OTK database cassandra connection port  |
 | `otk.database.cassandra.keyspace`          | OTK database cassandra keyspace |
-| `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}`
-| `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `true`
-| `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false`
-| `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config`
-| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6.
+| `otk.database.cassandra.driverConfig`      | OTK database cassandra driver config (Gateway 11+) | `{}` |
+| `otk.healthCheckBundle.enabled`            | Enable/Disable installation of OTK health check service bundle | `true` |
+| `otk.healthCheckBundle.useExisting`        | Use exising OTK health check service bundle | `false` |
+| `otk.healthCheckBundle.name`               | OTK health check service bundle name | `otk-health-check-bundle-config` |
+| `otk.livenessProbe.enabled`                | Enable/Disable. Requires otk.healthCheckBundle.enabled set to true and OTK version >= 4.6 |
 
 ```
 otk:


### PR DESCRIPTION
**Description of the change**

1. Adding some comments on usage of useDemoDb & dbUprgrade
2. Setting useDemoDb by default to false in production-values.yaml & docs
3. Fixed Readme rendering issues

**Benefits**

- Gives better clarity on the helm configuration. This requirement was an outcome of meetings with the customer NEXI

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

