### PR TITLE
[charts/gateway] Fix image tag formatting issue in OTEL

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.1.1"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.32
+version: 3.0.33
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -5,7 +5,7 @@ This Chart deploys the API Gateway v10.x onward with the following `optional` su
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.32
+- Current Chart Version 3.0.33
   - Please review release notes [here](./release-notes.md)
 
 ## Prerequisites

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -208,7 +208,7 @@ Define OTK Image Pull Secret Name
  Define OTEL_RESOURCE_ATTRIBUTES Environment variable
  */}}
 {{- define "gateway.otel.resource.attributes" -}}
-{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" quote .Values.image.tag }}
+{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" .Values.image.tag | quote  }}
 {{- if and (.Values.config.otel.sdkOnly.enabled) (.Values.config.otel.additionalResourceAttributes) -}}
  {{- $additionalResourceAttributes := join "," .Values.config.otel.additionalResourceAttributes }}
  {{- printf "%s,%s" $resourceAttributes $additionalResourceAttributes -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -208,8 +208,7 @@ Define OTK Image Pull Secret Name
  Define OTEL_RESOURCE_ATTRIBUTES Environment variable
  */}}
 {{- define "gateway.otel.resource.attributes" -}}
-{{ $imageTag := .Values.image.tag | quote }}
-{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" $imageTag }}
+{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" quote .Values.image.tag }}
 {{- if and (.Values.config.otel.sdkOnly.enabled) (.Values.config.otel.additionalResourceAttributes) -}}
  {{- $additionalResourceAttributes := join "," .Values.config.otel.additionalResourceAttributes }}
  {{- printf "%s,%s" $resourceAttributes $additionalResourceAttributes -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -208,7 +208,8 @@ Define OTK Image Pull Secret Name
  Define OTEL_RESOURCE_ATTRIBUTES Environment variable
  */}}
 {{- define "gateway.otel.resource.attributes" -}}
-{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" .Values.image.tag }}
+{{ $imageTag := .Values.image.tag | quote }}
+{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" $imageTag }}
 {{- if and (.Values.config.otel.sdkOnly.enabled) (.Values.config.otel.additionalResourceAttributes) -}}
  {{- $additionalResourceAttributes := join "," .Values.config.otel.additionalResourceAttributes }}
  {{- printf "%s,%s" $resourceAttributes $additionalResourceAttributes -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -208,7 +208,8 @@ Define OTK Image Pull Secret Name
  Define OTEL_RESOURCE_ATTRIBUTES Environment variable
  */}}
 {{- define "gateway.otel.resource.attributes" -}}
-{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" .Values.image.tag | quote  }}
+{{- $imageTag := .Values.image.tag | quote  -}}
+{{ $resourceAttributes := printf "%s,service.version=%s" "k8s.container.name=$(CONTAINER_NAME),k8s.deployment.name=$(OTEL_SERVICE_NAME),service.name=$(OTEL_SERVICE_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME)" $imageTag  }}
 {{- if and (.Values.config.otel.sdkOnly.enabled) (.Values.config.otel.additionalResourceAttributes) -}}
  {{- $additionalResourceAttributes := join "," .Values.config.otel.additionalResourceAttributes }}
  {{- printf "%s,%s" $resourceAttributes $additionalResourceAttributes -}}


### PR DESCRIPTION
**Description of the change**

Otel is not starting due to invalid characters in the the service.version global attribute, these invalid characters are added as .Values.image.tag is interpreted as number and converted to string %!s(int64=1265) when the actual image tag is 1265

**Benefits**

Fix for Otel boot up

**Drawbacks**

NA

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

