### PR TITLE
[charts/gateway] remove awk

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.1.2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.32
+version: 3.0.33
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -5,7 +5,7 @@ This Chart deploys the API Gateway v10.x onward with the following `optional` su
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.32
+- Current Chart Version 3.0.33
   - Please review release notes [here](./release-notes.md)
   - Gateway v11.1.2 onwards has updated defaults for config.log.override.properties
     - Please review your configuration and remove this line prior to upgrading to avoid log duplication

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -242,6 +242,8 @@ config:
       #   value: "true"
       # - name: otel.metricPrefix
       #   value: l7_
+      # - name: otel.attributePrefix
+      #   value: l7_
       # - name: otel.traceConfig
       #   value: |
       #     {

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,11 @@ The Layer7 API Gateway is now running with Java 17 with the release of v11.1.00.
 
 If you use Policy Manager, you will need to update to v11.1.00.
 
+## 3.0.33 General Updates
+This is a minor patch to remove the use of AWK in the following optional scripts
+- Bootstrap script
+- Graceful shutdown script
+
 ## 3.0.32 General Updates
 - Default image updated to v11.1.2
   - Gateway v11.1.2 onwards has updated defaults for config.log.override.properties

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -172,7 +172,7 @@ data:
         echo "***************************************************************************"
         echo "scanning for $TYPE in $SOURCE_DIR"
         echo "***************************************************************************"
-        FILES=$(du -a $3 | grep -e ".\\$2$" | awk '{ print $2 }' 2>/dev/null)
+        FILES=$(du -a $3 | grep -e ".\\$2$" | sed 's/\S*\s*\(\S*\).*/\1/' 2>/dev/null)
         for file in $FILES; do
             name=$(basename "$file")
             cp $file $4/$name
@@ -187,7 +187,7 @@ data:
         echo "***************************************************************************"
         echo "scanning for $TYPE in $SOURCE_DIR"
         echo "***************************************************************************"
-        FILES=$(du -a $3 | grep -e ".\\$2$" | awk '{ print $2 }' 2>/dev/null)
+        FILES=$(du -a $3 | grep -e ".\\$2$" | sed 's/\S*\s*\(\S*\).*/\1/' 2>/dev/null)
         for file in $FILES; do
             name=$(basename "$file")
             echo -e "running $name"
@@ -215,8 +215,7 @@ data:
     CHECK_INTERVAL=$2
     EXCLUDE="${@:3}"
     
-    PORTS=$(netstat -an | awk '/LISTEN/ { n = split($4, a, ":"); print a[n] }')
-    
+    PORTS=$(netstat -an | grep LISTEN | tr -s " " | cut -d " " -f4 | cut -d ":" -f2)
     if [ -z $PERIOD_SECONDS ]; then
     PERIOD_SECONDS=30
     fi
@@ -232,7 +231,7 @@ data:
         BUSY_PORTS=0
         for p in $PORTS; do
             # Check open connections
-            CONNECTIONS=$(netstat -anp | grep ESTABLISHED | grep java | awk '{ print $4 }' | grep :$p | wc -l)
+            CONNECTIONS=$(netstat -anp | grep ESTABLISHED | grep java | tr -s " " | cut -d " " -f4 | grep :$p | wc -l)
             if [ $CONNECTIONS -gt 0 ]; then
                 let BUSY_PORTS++
                 echo Port $p has $CONNECTIONS connection open

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -242,6 +242,8 @@ config:
       #   value: "true"
       # - name: otel.metricPrefix
       #   value: l7_
+      # - name: otel.attributePrefix
+      #   value: l7_
       # - name: otel.traceConfig
       #   value: |
       #     {


### PR DESCRIPTION
**Description of the change**
This is a minor patch to remove the use of AWK in the following optional scripts
- Bootstrap script
- Graceful shutdown script

**Applicable issues**
- Contents from /opt/docker/custom not being moved into correct locations
- Graceful shutdown script errors

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

