### PR TITLE
[charts/gateway] US1018555 Testing and Verification Part 2

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -379,7 +379,8 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
 | `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of demo test clients | `false` |
-| `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  |
+| `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  | |
+| `otk.database.changeLogSync`      | Applicable for OTK versions 4.6.3 & older only. If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|
 | `otk.database.updateConnection`   | Update database connection properties during helm upgrade | `true`|
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -379,8 +379,7 @@ OTK Deployment examples can be found [here](/examples/otk)
 | `otk.database.dbUpgrade`          | Enable/Disable OTK DB Upgrade| `true` |
 | `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of demo test clients | `false` |
-| `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  | |
-| `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|
+| `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) Required if createTestClients is `true`  |
 | `otk.database.updateConnection`   | Update database connection properties during helm upgrade | `true`|
 | `otk.database.connectionName`     | OTK database connection name | `OAuth`
 | `otk.database.existingSecretName` | Point to an existing OTK database Secret |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -815,10 +815,6 @@ otk:
     # Update database connection properties during helm upgrade.
     updateConnection: true
 
-    # If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true.
-    # This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade.
-    changeLogSync: false
-
     sql:
 
       # If provided, used to create OTK schema and tables.

--- a/charts/gateway/templates/otk-cr-db-secret.yaml
+++ b/charts/gateway/templates/otk-cr-db-secret.yaml
@@ -1,0 +1,26 @@
+{{ if and (.Values.management.restman.enabled) (.Values.otk.enabled) (.Values.otk.database.clientReadConnection.enabled) (not .Values.otk.database.clientReadConnection.existingSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "otk.dbSecretName.clientRead" . }}
+  labels:
+    app: {{ template "gateway.name" . }}
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- if  .Values.additionalAnnotations }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+{{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+{{- end }}
+{{- end }}
+type: Opaque
+data:
+  OTK_CLIENT_READ_DATABASE_PASSWORD : {{ required "Please fill in otk.database.clientReadConnection.password in values.yaml" .Values.otk.database.clientReadConnection.password | b64enc }}
+  OTK_CLIENT_READ_DATABASE_USERNAME : {{ required "Please fill in otk.database.clientReadConnection.username in values.yaml" .Values.otk.database.clientReadConnection.username| b64enc }}
+{{ end }}

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -55,10 +55,6 @@ spec:
           env:
            - name: OTK_TYPE
              value: {{ template "otk-install-type" .}}
-           {{- if and (not .Values.otk.database.useDemoDb) (.Values.otk.database.changeLogSync)}}
-           - name: OTK_LIQUIBASE_OPERATION
-             value: "changelogSync"
-           {{ end }}
            - name: OTK_DATABASE_TYPE
              value: {{ required "Please fill in otk.database.type in values.yaml" .Values.otk.database.type | quote }}
            - name: OTK_DATABASE_WAIT_TIMEOUT

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -73,10 +73,8 @@ spec:
            {{- else }}
              value: {{ required "Please fill in otk.database.sql.jdbcURL in values.yaml" .Values.otk.database.sql.jdbcURL | quote }}
            {{- end }}
-           {{- if eq .Values.otk.database.type "oracle" }}
            - name: OTK_DATABASE_NAME
              value: {{ required "Please fill in otk.database.sql.databaseName in values.yaml" .Values.otk.database.sql.databaseName | quote }}
-           {{- end }}
            - name: OTK_CREATE_TEST_CLIENTS
              value: {{ default "false" .Values.otk.database.sql.createTestClients | quote }}
            {{- if .Values.otk.database.sql.createTestClients }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -631,7 +631,7 @@ management:
 
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
-  type: ClusterIP
+  type: LoadBalancer
   ## Load Balancer sources
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   # loadBalancerSourceRanges:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -631,7 +631,7 @@ management:
 
 service:
   # Service Type, ClusterIP, NodePort, LoadBalancer
-  type: LoadBalancer
+  type: ClusterIP
   ## Load Balancer sources
   ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
   # loadBalancerSourceRanges:
@@ -814,10 +814,6 @@ otk:
 
     # Update database connection properties during helm upgrade.
     updateConnection: true
-
-    # If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true.
-    # This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade.
-    changeLogSync: false
 
     sql:
 

--- a/examples/otk/README.md
+++ b/examples/otk/README.md
@@ -59,7 +59,6 @@ The sub solution kits that are used in the installation or upgrade process are d
 ### MySQL or Oracle database (`otk.database.type:mysql/oracle`) 
 OTK MySQL or Oracle can be auto upgraded using the kubernetes job by setting `otk.database.dbUpgrade` to `true`. 
 > :information_source: **Important** <br>
-> If using existing non liquibase OTK DB, then perform manual OTK DB upgrade and set `otk.database.changeLogSync` to true. </br>This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade.
 
 Properties related to OTK database install/Upgrade.
 
@@ -70,7 +69,6 @@ Properties related to OTK database install/Upgrade.
 | `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of test clients | `true` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) required for demo test clients  | `true`  |
-| `otk.database.changeLogSync`      | If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|
 
 To configure external mysql/oracle database as OTK db, configure properties in below table.
 

--- a/examples/otk/README.md
+++ b/examples/otk/README.md
@@ -59,7 +59,8 @@ The sub solution kits that are used in the installation or upgrade process are d
 ### MySQL or Oracle database (`otk.database.type:mysql/oracle`) 
 OTK MySQL or Oracle can be auto upgraded using the kubernetes job by setting `otk.database.dbUpgrade` to `true`. 
 > :information_source: **Important** <br>
-
+> Applicable for OTK versions 4.6.3 & older only. If using existing non liquibase OTK DB, then perform manual OTK DB upgrade and set `otk.database.changeLogSync` to true. </br>This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade.
+> For OTK version 4.6.4 this is not necessary. The installation & upgrade process takes care of detecting this.
 Properties related to OTK database install/Upgrade.
 
 | Parameter                        | Description                               | Default                                                      |
@@ -69,6 +70,7 @@ Properties related to OTK database install/Upgrade.
 | `otk.database.useDemoDb`          | Enable/Disable OTK Demo DB | `true` |
 | `otk.database.sql.createTestClients`   | Enable/Disable creation of test clients | `true` |
 | `otk.database.sql.testClientsRedirectUrlPrefix`   | The value of redirect_uri prefix (Example: https://test.com:8443) required for demo test clients  | `true`  |
+| `otk.database.changeLogSync`      | Applicable for OTK versions 4.6.3 & older only. If using existing non liquibase OTK DB then perform manual OTK DB upgrade and set 'changeLogSync' to true. <br/> This is a onetime activity to initialize liquibase related tables on OTK DB. Set to false for successive helm upgrade. | `false`|
 
 To configure external mysql/oracle database as OTK db, configure properties in below table.
 


### PR DESCRIPTION
**Description of the change**

- Removing the config parameter changeLogSync
- The otk.database.type is required for MySQL (previously needed only for Oracle)
- Adding secret for Client Read JDBC connection

**Benefits**

Updated helm charts to be inline with the operator.

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

