### PR TITLE
charts/portal added usage pod annotation for tls-manager job

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.3.2"
 description: CA API Developer Portal
 name: portal
-version: 2.3.14
+version: 2.3.15
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/templates/jobs/cert-update-job.yaml
+++ b/charts/portal/templates/jobs/cert-update-job.yaml
@@ -21,6 +21,10 @@ metadata:
 spec:
   backoffLimit: 0
   template:
+    metadata:
+      {{- if  .Values.apim.podAnnotations }}
+      annotations: {{- toYaml .Values.apim.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "portal.serviceAccountName" . }}
       restartPolicy: Never

--- a/charts/portal/templates/jobs/cert-update-job.yaml
+++ b/charts/portal/templates/jobs/cert-update-job.yaml
@@ -22,8 +22,8 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      {{- if  .Values.apim.podAnnotations }}
-      annotations: {{- toYaml .Values.apim.podAnnotations | nindent 8 }}
+      {{- if  .Values.jobs.podAnnotations }}
+      annotations: {{- toYaml .Values.jobs.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "portal.serviceAccountName" . }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -957,6 +957,7 @@ ingress-nginx:
 
 # Settings for portal jobs
 jobs:
+  podAnnotations: {}
   labels: {}
 # nodeSelector: {}
 # tolerations: []

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -812,6 +812,7 @@ ingress-nginx:
 
 # Settings for portal jobs
 jobs:
+  podAnnotations: {}
   labels: {}
   # nodeSelector: {}
   # tolerations: []


### PR DESCRIPTION
**Description of the change**

added usage pod annotation for tls-manager job

**Benefits**

you can add a pod annaotation to the tls-manager job

**Drawbacks**

none

**Applicable issues**

Case #: 36332852
  - fixes #

**Additional information**
We need this for the deployment on AKS
The creation of the secrets fails because the script within the tls-manager job fails because it cannot reach the kubernetes API.
In AKS you need to set the annotation:  kubernetes.azure.com/set-kube-service-host-fqdn: ""

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

