### PR TITLE
[charts/gateway] update pm-tagger

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.1.2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.34
+version: 3.0.35
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,11 +1,11 @@
-ƒ# Layer7 API Gateway
+# Layer7 API Gateway
 This Chart deploys the API Gateway v10.x onward with the following `optional` subcharts: hazelcast, mysql, influxdb, grafana, redis.
 
 ### Important Note
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.34
+- Current Chart Version 3.0.35
   - Please review release notes [here](./release-notes.md)
 
 ## Prerequisites
@@ -199,7 +199,6 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `service.annotations`    | Additional annotations to add to the service               | {} |
 | `service.internalTrafficPolicy`    | [Internal Traffic Policy](https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/#using-service-internal-traffic-policy)               | `Cluster` |
 | `service.externalTrafficPolicy`    | [External Traffic Policy](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip)               | `Cluster` |
-
 | `ingress.enabled`    | Enable/Disable an ingress or route record being created               | `false` |
 | `ingress.openshift.route.enabled`    | Create an Openshift Route (Requires Openshift)               | `false` |
 | `ingress.openshift.route.wildcardPolicy`    | Openshift Route Wildcard Policy               | `None` |
@@ -665,8 +664,8 @@ ingress:
 | `pmtagger.enabled`          | Enable pm-tagger | `false`  |
 | `pmtagger.replicas`          | Replicas (you should never need more than one | `1`  |
 | `pmtagger.image.registry`          | Image Registry | `docker.io`  |
-| `pmtagger.image.repository`          | Image Repository | `layer7api/pm-tagger`  |
-| `pmtagger.image.tag`          | Image Tag | `1.0.1`  |
+| `pmtagger.image.repository`          | Image Repository | `caapim/pm-tagger`  |
+| `pmtagger.image.tag`          | Image Tag | `1.0.2`  |
 | `pmtagger.image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `pmtagger.image.imagePullSecret.enabled`                | Use Image Pull secret - this uses the image pull secret configured for the API Gateway   | `false` |
 | `pmtagger.resources`                | Resources   | `see values.yaml` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -80,8 +80,8 @@ pmtagger:
   replicas: 1
   image:
     registry: docker.io
-    repository: layer7api/pm-tagger
-    tag: 1.0.1
+    repository: caapim/pm-tagger
+    tag: 1.0.2
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -609,6 +609,13 @@ management:
     type: LoadBalancer
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Set the ExternalIPs
+    # externalIPs:
+    ## Set the LoadBalancerIP
+    # loadBalancerIP:
+    # loadBalancerClass: "mylbclass"
     annotations: {}
       # cloud.google.com/load-balancer-type: "Internal"
     ports:
@@ -642,7 +649,7 @@ service:
   # externalIPs:
   ## Set the LoadBalancerIP
   # loadBalancerIP:
-
+  # loadBalancerClass: "mylbclass"
   # Update this port list if additional ports need to be exposed
   ports:
     - name: https

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -8,9 +8,10 @@ The Layer7 API Gateway is now running with Java 17 with the release of v11.1.00.
 If you use Policy Manager, you will need to update to v11.1.00.
 
 ## 3.0.35 General Updates
-This is a minor patch to update pm-tagger and fix the readme format.
+This is a minor patch to update pm-tagger, fix the readme format and add optional loadBalancerClass for services.
 - PM-Tagger image updated (docker.io/caapim/pm-tagger:1.0.2)
 - Readme format fix
+- Added loadBalancerClass for services (optional)
 
 ## 3.0.34 OTK 4.6.4 Released
 - The default image tag in values.yaml and production-values.yaml for OTK updated to 4.6.4.

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,11 @@ The Layer7 API Gateway is now running with Java 17 with the release of v11.1.00.
 
 If you use Policy Manager, you will need to update to v11.1.00.
 
+## 3.0.35 General Updates
+This is a minor patch to update pm-tagger and fix the readme format.
+- PM-Tagger image updated (docker.io/caapim/pm-tagger:1.0.2)
+- Readme format fix
+
 ## 3.0.34 OTK 4.6.4 Released
 - The default image tag in values.yaml and production-values.yaml for OTK updated to 4.6.4.
   - otk.job.image.tag: 4.6.4

--- a/charts/gateway/templates/management-service.yaml
+++ b/charts/gateway/templates/management-service.yaml
@@ -28,6 +28,9 @@ spec:
   {{- if .Values.management.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.management.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.management.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.management.service.loadBalancerClass }}
+  {{- end }}
   {{- end }}
   {{- if .Values.management.service.externalIPs }}
   externalIPs: {{- toYaml .Values.management.service.externalIPs | nindent 4 }}

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -26,6 +26,9 @@ spec:
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+  {{- end }}
   {{- end }}
   {{- if .Values.service.externalIPs }}
   externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -80,8 +80,8 @@ pmtagger:
   replicas: 1
   image:
     registry: docker.io
-    repository: layer7api/pm-tagger
-    tag: 1.0.1
+    repository: caapim/pm-tagger
+    tag: 1.0.2
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -609,6 +609,13 @@ management:
     type: LoadBalancer
     ## Load Balancer sources
     ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    # loadBalancerSourceRanges:
+    # - 10.10.10.0/24
+    ## Set the ExternalIPs
+    # externalIPs:
+    ## Set the LoadBalancerIP
+    # loadBalancerIP:
+    # loadBalancerClass: "mylbclass"
     annotations: {}
       # cloud.google.com/load-balancer-type: "Internal"
     ports:
@@ -642,7 +649,7 @@ service:
   # externalIPs:
   ## Set the LoadBalancerIP
   # loadBalancerIP:
-
+  # loadBalancerClass: "mylbclass"
   # Update this port list if additional ports need to be exposed
   ports:
     - name: https


### PR DESCRIPTION
**Description of the change**
This is a minor patch to update pm-tagger, fix the readme format and add optional loadBalancerClass for services.
- PM-Tagger image updated (docker.io/caapim/pm-tagger:1.0.2)
- Readme format fix
- Added loadBalancerClass for services (optional)

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

