### PR TITLE
[charts/portal] Switch bitnami/mysql to bitnamilegacy/mysql

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.3.3.1"
 description: CA API Developer Portal
 name: portal
-version: 2.3.17
+version: 2.3.18
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -6,6 +6,9 @@ This Chart deploys the Layer7 API Developer Portal on a Kubernetes Cluster using
 
 ## Release Notes
 
+## 2.3.18 General Updates
+- Switch bitnami/mysql to bitnamilegacy/mysql.
+
 ## 2.3.16 General Updates
 - This new version of the chart supports API Portal 5.3.3.1
 - Upgrade to 2.3.17 is only supported from 2.3.10 chart version as per the Portal version.

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -35,6 +35,9 @@ global:
   helpPage: https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-developer-portal/5-3/
 # storageClass: "_"
 # schedulerName:
+  # required by bitnamilegacy/mysql
+  security:
+    allowInsecureImages: true
 
 portal:
   domain: example.com
@@ -980,6 +983,7 @@ jobs:
 mysql:
   image:
     tag: "8.4.4-debian-12-r0"
+    repository: bitnamilegacy/mysql
   auth:
     username: portal
     existingSecret: database-secret

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -37,6 +37,9 @@ global:
 # schedulerName:
 # The saas flag should be left as is unless otherwise specified by support.
 # saas: false
+  # required by bitnamilegacy/mysql
+  security:
+    allowInsecureImages: true
 
 portal:
   domain: example.com
@@ -834,6 +837,7 @@ jobs:
 mysql:
   image:
     tag: "8.4.4-debian-12-r0"
+    repository: bitnamilegacy/mysql
   auth:
     username: portal
     existingSecret: database-secret


### PR DESCRIPTION
**Description of the change**

Switch bitnami/mysql to bitnamilegacy/mysql in portal helm chart

**Benefits**

Portal deployment with helm will continue working with mysql container

**Drawbacks**

None.

**Applicable issues**

Bitnami announced the retirement of all current docker images on dockerhub.
[https://community.broadcom.com/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon](https://www.google.com/url?q=https://community.broadcom.com/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon&source=gmail-imap&ust=1758747235000000&usg=AOvVaw01IfohWwRKo-YE36rWmrLy)
[https://github.com/bitnami/containers/issues/83267](https://www.google.com/url?q=https://github.com/bitnami/containers/issues/83267&source=gmail-imap&ust=1758747235000000&usg=AOvVaw0FM2gTesO_i4sf9mkhCHiu)

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

