### PR TITLE
[charts/gateway] US1052945: Update pm-tagger tag from 1.0.2 to 1.0.3

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -650,7 +650,7 @@ ingress:
 | `pmtagger.replicas`          | Replicas (you should never need more than one | `1`  |
 | `pmtagger.image.registry`          | Image Registry | `docker.io`  |
 | `pmtagger.image.repository`          | Image Repository | `layer7api/pm-tagger`  |
-| `pmtagger.image.tag`          | Image Tag | `1.0.1`  |
+| `pmtagger.image.tag`          | Image Tag | `1.0.3`  |
 | `pmtagger.image.pullPolicy`          | Image Pull Policy | `IfNotPresent`  |
 | `pmtagger.image.imagePullSecret.enabled`                | Use Image Pull secret - this uses the image pull secret configured for the API Gateway   | `false` |
 | `pmtagger.resources`                | Resources   | `see values.yaml` |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -83,7 +83,7 @@ pmtagger:
   image:
     registry: docker.io
     repository: caapim/pm-tagger
-    tag: 1.0.2
+    tag: 1.0.3
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -83,7 +83,7 @@ pmtagger:
   image:
     registry: docker.io
     repository: caapim/pm-tagger
-    tag: 1.0.2
+    tag: 1.0.3
     pullPolicy: IfNotPresent
 # Uses the image pull secret configured for the Gateway.
   imagePullSecret:


### PR DESCRIPTION
**Description of the change**

Update pm-tagger from 1.0.2 to 1.0.3.

**Benefits**

pm-tagger 1.0.3 is multi-arch image for amd64 and arm64.

**Drawbacks**

None.

**Applicable issues**

N/A

**Additional information**
-  pm-tagger image deployed on node amr64 - PASS
   
<img width="700" height="500" alt="Screenshot 2025-09-26 at 10 13 15 PM" src="https://github.com/user-attachments/assets/2ff16850-c537-47e0-88a8-149aba1fa8ea" />

- ATF Routing tests using this PR branch - PASS
- Chart version will be bumped when develop/gateway is merged to stable (PR to be created).
- Will run all ATF tests in develop/gateway


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

