### PR TITLE
Remove extra env section

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -413,11 +413,6 @@ spec:
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: {{ template "gateway.otel.resource.attributes" . }}
           {{- end }}
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
           envFrom:
             - configMapRef:
                 name: {{ template "gateway.fullname" . }}-configmap


### PR DESCRIPTION
**Description of the change**

Remove the env section which is likely introduced by original gemfire work which is overriding env for otel. This part is not needed for gemfire feature to work.

This addresses otel failure on GKE, see DE648720

**Additional information**
Passed on Trident with this change:
<img width="1064" height="858" alt="image" src="https://github.com/user-attachments/assets/cc433c36-6a4c-406a-9f30-1f084b0a5b94" />

Passed on Develop
<img width="1070" height="882" alt="image" src="https://github.com/user-attachments/assets/f5bfc251-c766-4954-825f-7231ca22b08a" />


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

