### PR TITLE
[charts/gateway] Add NodePort support for Gateway and Management Services

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -268,7 +268,7 @@ service:
 
 ### Production Values Default
 Sample entry that exposes 8443 which is one of the default TLS ports on the API Gateway
-Note that the service type is ClusterIP which does not receive an external IP address. We can make this service accessible by configuring an [ingress resource](#ingress-configuration).
+Note that the service type is ClusterIP which does not receive an external IP address. We can make this service accessible by configuring an [ingress resource](#ingress-configuration). If direct external access is needed, we can make this service of type NodePort and uncomment the nodePort value. Set the nodePort port number to the actual port you want each Kubernetes Worker Node to listen on for the Gateway Service.
 
 ```
 service:
@@ -278,11 +278,11 @@ service:
     - name: https
       internal: 8443
       external: 8443
-      #nodePort: 8443
+      #nodePort: 30443
       protocol: TCP
 ```
 ### Gateway Management Service
-The Gateway Management Service is primarily used to expose Gateway Ports that you wish to use for Internal Management Access for tools like Policy Manager. This Service requires the [PM Tagger](#pm-tagger) to function correctly.
+The Gateway Management Service is primarily used to expose Gateway Ports that you wish to use for Internal Management Access for tools like Policy Manager. This Service requires the [PM Tagger](#pm-tagger) to function correctly. Like the main service, the Management Service can be set to type NodePort and the nodePort value uncommented to provide direct external access to the service.
 
 ```
 management:
@@ -297,7 +297,7 @@ management:
       - name: management
         internal: 9443
         external: 9443
-        #nodePort: 9443
+        #nodePort: 31443
         protocol: TCP
 ```
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -278,6 +278,7 @@ service:
     - name: https
       internal: 8443
       external: 8443
+      #nodePort: 8443
       protocol: TCP
 ```
 ### Gateway Management Service
@@ -296,6 +297,7 @@ management:
       - name: management
         internal: 9443
         external: 9443
+        #nodePort: 9443
         protocol: TCP
 ```
 

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -704,13 +704,16 @@ management:
     annotations: {}
       # cloud.google.com/load-balancer-type: "Internal"
     ports:
+      ## If using type: NodePort above, include nodePort value in each port object below
       # - name: https
       #   internal: 8443
       #   external: 8443
+      #   nodePort: 30443
       #   protocol: TCP
       - name: management
         internal: 9443
         external: 9443
+        #nodePort: 31443
         protocol: TCP
     # Uncomment the following section to enable session affinity
     # sessionAffinity: ClientIP
@@ -743,13 +746,16 @@ service:
   # loadBalancerClass: "mylbclass"
   # Update this port list if additional ports need to be exposed
   ports:
+    ## If using type: NodePort above, include nodePort value in each port object below
     - name: https
       internal: 8443
       external: 8443
+      #nodePort: 30443
       protocol: TCP
     # - name: management
     #   internal: 9443
     #   external: 9443
+    #   nodePort: 31443
     #   protocol: TCP
   # Additional Service annotations, the example below shows configuration for an internal load balancer on GCP
   # See the docs for more ==> https://kubernetes.io/docs/concepts/services-networking/service/

--- a/charts/gateway/templates/management-service.yaml
+++ b/charts/gateway/templates/management-service.yaml
@@ -47,6 +47,9 @@ spec:
       port: {{ .external }}
       targetPort: {{ .name }}
       name: {{ .name | quote }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
   {{- end }}
   {{- if .Values.management.service.sessionAffinity }}
   sessionAffinity: {{ .Values.management.service.sessionAffinity }}

--- a/charts/gateway/templates/management-service.yaml
+++ b/charts/gateway/templates/management-service.yaml
@@ -47,7 +47,7 @@ spec:
       port: {{ .external }}
       targetPort: {{ .name }}
       name: {{ .name | quote }}
-      {{- if .nodePort }}
+      {{- if and ( .nodePort ) (eq $.Values.management.service.type "NodePort") }}
       nodePort: {{ .nodePort }}
       {{- end }}
   {{- end }}

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -45,7 +45,7 @@ spec:
       port: {{ .external }}
       targetPort: {{ .name }}
       name: {{ .name | quote }}
-      {{- if .nodePort }}
+      {{- if and ( .nodePort ) (eq $.Values.service.type "NodePort") }}
       nodePort: {{ .nodePort }}
       {{- end }}
   {{- end }}

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -45,6 +45,9 @@ spec:
       port: {{ .external }}
       targetPort: {{ .name }}
       name: {{ .name | quote }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
   {{- end }}
   {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -700,13 +700,16 @@ management:
     annotations: {}
       # cloud.google.com/load-balancer-type: "Internal"
     ports:
+      ## If using type: NodePort above, include nodePort value in each port object below
       # - name: https
       #   internal: 8443
       #   external: 8443
+      #   nodePort: 30443
       #   protocol: TCP
       - name: management
         internal: 9443
         external: 9443
+        # nodePort: 31443
         protocol: TCP
     # Uncomment the following section to enable session affinity
     # sessionAffinity: ClientIP
@@ -739,13 +742,16 @@ service:
   # loadBalancerClass: "mylbclass"
   # Update this port list if additional ports need to be exposed
   ports:
+    ## If using type: NodePort above, include nodePort value in each port object below
     - name: https
       internal: 8443
       external: 8443
+      #nodePort: 30443
       protocol: TCP
     # - name: management
     #   internal: 9443
     #   external: 9443
+    #   nodePort: 31443
     #   protocol: TCP
   # Additional Service annotations, the example below shows configuration for an internal load balancer on GCP
   # See the docs for more ==> https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
**Description of the change**

Add NodePort capacity to the templates for the gateway service and gateway-magagement service.  This PR should satisfy the feature request in https://github.com/CAAPIM/apim-charts/issues/414 

**Benefits**

Helm Chart users can set their services to NodePort for both development and production purposes, and allow direct external access to the exposed services using the Kubernetes Worker Nodes' IP or FQHN and a values-controlled `nodePort` assignment

**Drawbacks**

These changes only apply to the Gateway Service and Management Service, not the Gemfire addon or any other K8s Services that may be created by the Gateway Chart.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #414 

**Additional information**

Included a safety feature to prevent the `nodePort` value from being used if the services' types are not `NodePort`.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

