### PR TITLE
[charts/portal] Fix DE651097 - stable - Make portal db-upgrade-portal/rbac jobs resources configurable

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.4"
 description: CA API Developer Portal
 name: portal
-version: 2.3.19
+version: 2.3.20
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -6,6 +6,9 @@ This Chart deploys the Layer7 API Developer Portal on a Kubernetes Cluster using
 
 ## Release Notes
 
+## 2.3.20 General Updates
+- This new version of the chart makes Portal db-upgrade-portal/rbac resource configurable per customer request.
+
 ## 2.3.19 General Updates
 - This new version of the chart supports API Portal 5.4
 - DB container(for testing) upgraded to support 8.4.5 MySQL version.

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -480,6 +480,8 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `jobs.image.PullPolicy`                                        | Image pull policy applied to jobs                                                                                            | `IfNotPresent`                                 |
 | `jobs.podSecurityContext`                                      | Pod's security context settings applied to jobs. Overrides global.podSecurityContext settings                                | `{} evaluated as a template`                                 |
 | `jobs.containerSecurityContext`                                | Container's security context settings applied to jobs. Overrides global.containerSecurityContext settings                    | `{} evaluated as a template`                                 |
+| `jobs.dbUpgradePortal.resources`                               | Resource request/limits                                                                                                      | `{} evaluated as a template`                                 |
+| `jobs.dbUpgradeRbac.resources`                                 | Resource request/limits                                                                                                      | `{} evaluated as a template`                                 |
 
 ### Database Node Pool Configurations
 

--- a/charts/portal/templates/jobs/db-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/db-upgrade-job.yaml
@@ -36,6 +36,9 @@ spec:
           {{- if .Values.global.containerSecurityContext }}
           securityContext: {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           {{- end }}
+          {{- if .Values.jobs.dbUpgradePortal.resources }}
+          resources: {{- toYaml .Values.jobs.dbUpgradePortal.resources | nindent 12 }}
+          {{- end }}
           env:
            - name: HOST
          {{ if .Values.global.setupDemoDatabase }}

--- a/charts/portal/templates/jobs/rbac-upgrade-job.yaml
+++ b/charts/portal/templates/jobs/rbac-upgrade-job.yaml
@@ -36,6 +36,9 @@ spec:
           {{- if .Values.global.containerSecurityContext }}
           securityContext: {{- toYaml .Values.global.containerSecurityContext | nindent 12 }}
           {{- end }}
+          {{- if .Values.jobs.dbUpgradeRbac.resources }}
+          resources: {{- toYaml .Values.jobs.dbUpgradeRbac.resources | nindent 12 }}
+          {{- end }}
           env:
            - name: HOST
          {{ if .Values.global.setupDemoDatabase }}

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -975,7 +975,22 @@ jobs:
   # set default imagePullPolicy for db-upgrade-portal, db-upgrade-rbac and cert-upgrade jobs
   image:
     pullPolicy: IfNotPresent
-
+  dbUpgradePortal:
+    resources:
+      requests: {}
+      # cpu: 100m
+      # memory: 250Mi
+      limits: {}
+      # cpu: 1000m
+      # memory: 1000Mi
+  dbUpgradeRbac:
+    resources:
+      requests: {}
+      # cpu: 100m
+      # memory: 250Mi
+      limits: {}
+      # cpu: 1000m
+      # memory: 1000Mi
 
 # We recommend that MySQL is externalised, the default implementation here is for reference only and is NOT suitable for use
 # in any production environment.

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -831,6 +831,22 @@ jobs:
   image:
     pullPolicy: IfNotPresent
 
+  dbUpgradePortal:
+    resources:
+      requests: {}
+      # cpu: 100m
+      # memory: 250Mi
+      limits: {}
+      # cpu: 1000m
+      # memory: 1000Mi
+  dbUpgradeRbac:
+    resources:
+      requests: {}
+      # cpu: 100m
+      # memory: 250Mi
+      limits: {}
+      # cpu: 1000m
+      # memory: 1000Mi
 # We recommend that MySQL is externalised, the default implementation here is for reference only and is NOT suitable for use
 # in any production environment.
 # MySQL Stable Chart values - https://github.com/bitnami/charts/tree/master/bitnami/mysql


### PR DESCRIPTION
**Description of the change**

Customer asks to make portal helm chart to make db-upgrade-portal and db-upgrade-rbac job resources configurable.

**Benefits**

see above.

**Drawbacks**

none.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #[DE651097](https://rally1.rallydev.com/#/56297300379d/iterationstatus?detail=%2Fdefect%2F836106859213%2Fdetails)

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

