### PR TITLE
[charts/gateway] US1058306: Release OTK minor 4.6.x.x versions

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.0"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.39
+version: 3.0.40
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.0"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.40
+version: 3.0.41
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -73,6 +73,7 @@ Helm Version    Supported Kubernetes Versions
 * [Service Configuration](#port-configuration)
 * [Gateway Application Ports](#gateway-application-ports)
 * [OTK Install or Upgrade](#otk-install-or-upgrade)
+* [OTK Compatibility with Gateway 11.2](#otk-compatibility-with-gateway-112)
 * [Ingress Configuration](#ingress-configuration)
 * [PM Tagger Configuration](#pm-tagger-configuration)
 * [Shared State Preview Features](#shared-state-preview-features)
@@ -301,6 +302,19 @@ management:
 ```
 
 [Back to Additional Guides](#additional-guides)
+
+### OTK Compatibility with Gateway 11.2
+These below information is relevant for those who are upgrading their Gateway to version 11.2 and utilizing the OAuth Toolkit (OTK)
+1. **OTK 4.6.4** is presently the only version that provides seamless support for Gateway 11.2
+2. For older versions (< OTK 4.6.4), the below steps have to be followed to ensure smooth transition to Gateway 11.2
+   * After upgrading Gateway to 11.2 If there is a necessity to install or upgrade to OTK version 4.6.3, 4.6.2, 4.6.1, or 4.6.0, please ensure to update the OTK image tag to use one of the below tags corresponding to the specific version being deployed:
+       * 4.6.0.1
+       * 4.6.1.1
+       * 4.6.2.1
+       * 4.6.3.1
+   * It has to be ensured that Evaluate JSON Path Assertion (V1) assertion is added to the GW. 
+     * This will be provided as Tactical assertion. Please find more information on how to get the assertion [here](https://techdocs.broadcom.com/us/en/ca-enterprise-software/layer7-api-management/api-management-oauth-toolkit/4-6/release-notes.html)
+     * In Helm chart, this can be done using init Containers. For more information & examples refer to [Utilities](https://github.com/Layer7-Community/Utilities/tree/main/gateway-init-container-examples)
 
 ### OTK install or upgrade
 OTK can be install or upgrade gateway.  Supports SINGLE, INTERNAL and DMZ types of OTK installations on db backed gateway. On ephermal gateway only SINGLE mode is supported.

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -8,7 +8,7 @@ In preparation for the [Bitnami public catalog deletion](https://community.broad
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.40
+- Current Chart Version 3.0.41
   - Please review release notes [here](./release-notes.md)
 
 ## Prerequisites

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -8,7 +8,7 @@ In preparation for the [Bitnami public catalog deletion](https://community.broad
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.39
+- Current Chart Version 3.0.40
   - Please review release notes [here](./release-notes.md)
 
 ## Prerequisites

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -859,7 +859,7 @@ otk:
       tag: 4.6.4
       # OTK 4.6.4 is presently the only version that provides seamless support for Gateway 11.2
       # There are limitations in older versions (< OTK 4.6.4) with respect to Evaluate JSON Path Assertion (V1) assertion & other support limitations
-      # This requires specific actions as mentioned in the release notes Chart Version 3.0.39
+      # This requires specific actions as mentioned in the release notes Chart Version 3.0.41
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -856,6 +856,9 @@ otk:
     image:
       repository: caapim/otk-install
       tag: 4.6.4
+      # OTK 4.6.4 is presently the only version that provides seamless support for Gateway 11.2
+      # There are limitations in older versions (< OTK 4.6.4) with respect to Evaluate JSON Path Assertion (V1) assertion & other support limitations
+      # This requires specific actions as mentioned in the release notes Chart Version 3.0.39
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,7 +7,8 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
-For Specific compatibility changes related to OTK, please refer to [here](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#otk-compatibility-with-gateway-112) to have continous support
+## 3.0.40 General Updates
+For Specific compatibility changes related to OTK, please refer to [here](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#otk-compatibility-with-gateway-112) to have continuous support
 
 ## 3.0.39 General Updates
 - Add using initContainer to mount secret

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,8 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
+For Specific compatibility changes related to OTK, please refer to [here](https://github.com/CAAPIM/apim-charts/blob/stable/charts/gateway/README.md#otk-compatibility-with-gateway-112) to have continous support
+
 ## 3.0.39 General Updates
 - Add using initContainer to mount secret
 - Update GemFire version to 10.2.0 and GemFire management console version to 1.4.1

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -852,6 +852,9 @@ otk:
     image:
       repository: caapim/otk-install
       tag: 4.6.4
+      # OTK 4.6.4 is presently the only version that provides seamless support for Gateway 11.2
+      # There are limitations in older versions (< OTK 4.6.4) with respect to Evaluate JSON Path Assertion (V1) assertion & other support limitations
+      # This requires specific actions as mentioned in the release notes Chart Version 3.0.39
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -855,7 +855,7 @@ otk:
       tag: 4.6.4
       # OTK 4.6.4 is presently the only version that provides seamless support for Gateway 11.2
       # There are limitations in older versions (< OTK 4.6.4) with respect to Evaluate JSON Path Assertion (V1) assertion & other support limitations
-      # This requires specific actions as mentioned in the release notes Chart Version 3.0.39
+      # This requires specific actions as mentioned in the release notes Chart Version 3.0.41
       pullPolicy: IfNotPresent
     imagePullSecret:
       enabled: false


### PR DESCRIPTION
**Description of the change**

Documenting Compatibility issues & handling for Gateway 11.2

**Benefits**
**Drawbacks**
**Applicable issues**
**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [NA] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [NA] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

