### PR TITLE
Add default property for embedded gemfire

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.0"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.39
+version: 3.0.40
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -563,7 +563,8 @@ config:
       enabled: false
       caches:
         # Additional properties for embedded GemFire caches.
-#        additionalProperties: |-
+        additionalProperties: |-
+          statistic-sampling-enabled=false
 
       externalLocators:
         # The number of GemFire locator replicas to deploy when using embedded GemFire.

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,9 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
+## 3.0.40 General Updates
+- Add default property for embedded gemfire
+
 ## 3.0.39 General Updates
 - Add using initContainer to mount secret
 - Update GemFire version to 10.2.0 and GemFire management console version to 1.4.1

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,8 +7,8 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
-## 3.0.40 General Updates
-- Add default property for embedded gemfire
+## 3.0.40 General Updates 
+- Gemfire property statistic-sampling-enabled=false is added to disable Statistic sampling which is not supported for embedded gemfire on container gateway  
 
 ## 3.0.39 General Updates
 - Add using initContainer to mount secret

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -563,7 +563,8 @@ config:
       enabled: false
       caches:
         # Additional properties for embedded GemFire caches.
-#        additionalProperties: |-
+        additionalProperties: |-
+          statistic-sampling-enabled=false
 
       externalLocators:
         # The number of GemFire locator replicas to deploy when using embedded GemFire.


### PR DESCRIPTION
**Description of the change**

Set property for embedded gemfire to disable statistic by default


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

