### PR TITLE
[charts/gateway] update otk job labels

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.0"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.0.43
+version: 3.0.44
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -8,7 +8,7 @@ In preparation for the [Bitnami public catalog deletion](https://community.broad
 The included MySQL subChart is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.0.41
+- Current Chart Version 3.0.44
   - Please review release notes [here](./release-notes.md)
 
 ## Prerequisites

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,9 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
+## 3.0.44 General Updates
+This patch resolves conflicting labels/selectors for the OTK install, upgrade and scheduled task jobs. 
+
 ## 3.0.43 General Updates
 For Redis data provider, config.redis.tls.redisCrt is no longer required when config.redis.tls.verifyPeer is false
 

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "gateway.fullname" . }}
+        app: {{ template "gateway.fullname" . }}-otk-db-upgrade
         release: {{ .Release.Name }}
     {{- if  .Values.otk.job.podLabels }}
         {{- toYaml .Values.otk.job.podLabels | nindent 8 }}

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -28,7 +28,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "gateway.fullname" . }}
+        app: {{ template "gateway.fullname" . }}-otk-install
         release: {{ .Release.Name }}
     {{- if  .Values.otk.job.podLabels }}
         {{- toYaml .Values.otk.job.podLabels | nindent 8 }}

--- a/charts/gateway/templates/otk-scheduled-task-jobs.yaml
+++ b/charts/gateway/templates/otk-scheduled-task-jobs.yaml
@@ -32,7 +32,7 @@ spec:
       template:
         metadata:
           labels:
-            app: {{ template "gateway.fullname" $}}
+            app: {{ template "gateway.fullname" $}}-dbmaintenance-{{ .name }}
             release: {{ $.Release.Name }}
         {{- if  $.Values.otk.job.podLabels }}
             {{- toYaml $.Values.otk.job.podLabels | nindent 12}}


### PR DESCRIPTION
**Description of the change**
This is a patch that resolves conflicting labels/selectors for the OTK install, upgrade and scheduled task jobs. 

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

