### PR TITLE
US1077048 Update Readme and example for otel.serviceLevelTraceConfig

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -707,6 +707,8 @@ OpenTelemetry is configured on the Gateway in two places, system properties and 
 
 These can be configured in values.yaml. See the section below to view examples of how and where to configure this.
 
+The Gateway from v11.2.2, trace can use otel.serviceLevelTraceConfig as more granular per-service configuration . It takes precedence over otel.traceConfig when present. Please see Techdocs for more details about this integration.
+
 - config.otel
 ```
 config:
@@ -740,6 +742,20 @@ otel.enabled=true
 otel.serviceMetricEnabled=true
 otel.traceEnabled=true (if tracing is required)
 otel.traceConfig=(default {})
+otel.serviceLevelTraceConfig=(default {})   //GW 11.2.2  
+```
+example otel.serviceLevelTraceConfig
+```
+{
+  "services" : [ {
+    "resolutionPath" : "/*"
+  }, {
+    "resolutionPath" : ".*test_otel_service.*",
+    "assertions" : {
+      "exclude" : [ "Decode MTOM Message" ]
+    }
+  } ]
+}
 ```
 example otel.traceConfig
 ```

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -270,6 +270,18 @@ config:
       #         ]
       #       }
       #     }
+      # - name: otel.serviceLevelTraceConfig
+      #   value: |
+      #  {
+      #    "services": [ {
+      #      "resolutionPath": "/*"
+      #    }, {
+      #      "resolutionPath": ".*test_otel_service.*",
+      #      "assertions": {
+      #        "exclude": [ "Decode MTOM Message" ]
+      #      }
+      #    } ]
+      #  }
   systemProperties: |-
     # Default Gateway system properties
     # Configuration properties for shared state extensions.


### PR DESCRIPTION
**Description of the change**

Add OpenTelemetry related CWP otel.serviceLevelTraceConfig configuration in readme and example. This is for GW 11.2.2 release

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

