### PR TITLE
[charts/portal] Add S3 env vars to intelligence server and apim

### DIFF
--- a/charts/intelligence/README.md
+++ b/charts/intelligence/README.md
@@ -61,6 +61,19 @@ These values are typically provided by a parent chart.
 | `intelligenceServer.service.internalTrafficPolicy` | The internal traffic policy for the intelligence-server service. | `""` |
 | `intelligenceServer.portalDataHost` | The host and port for the portal data service. | `"portal-data:8080"` |
 
+### S3 Storage settings
+
+The Intelligence Server **requires** S3-compatible storage (SeaweedFS) for data persistence. When deployed as part of the Portal chart, SeaweedFS is automatically deployed when intelligence is enabled.
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `intelligenceServer.s3.url` | S3 URL (endpoint) | `http://seaweedfs-s3:8333` |
+| `intelligenceServer.s3.pathStyleAccess` | Use path-style access for S3 | `true` |
+| `intelligenceServer.s3.accessKeyKey` | Secret key for S3 access key | `admin_access_key_id` |
+| `intelligenceServer.s3.secretKeyKey` | Secret key for S3 secret key | `admin_secret_access_key` |
+| `global.deepStorage.auth.secretName` | Secret containing S3 credentials | `seaweedfs-s3-secret` |
+| `global.deepStorage.analytics.bucketName` | S3 bucket name for analytics data | `api-metrics` |
+
 ### Kafka settings
 
 The Intelligence Server requires a connection to a Kafka cluster. The following settings are used to configure the connection.

--- a/charts/intelligence/templates/server/s3-secret.yaml
+++ b/charts/intelligence/templates/server/s3-secret.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.intelligenceServer.s3.enabled (not .Values.intelligenceServer.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "intelligence.fullname" . }}-s3-secret
+  labels:
+    app: intelligence-server
+    chart: {{ template "intelligence.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- if .Values.intelligenceServer.s3.accessKey }}
+  access-key: {{ .Values.intelligenceServer.s3.accessKey | b64enc | quote }}
+  {{- else }}
+  access-key: {{ "" | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.intelligenceServer.s3.secretKey }}
+  secret-key: {{ .Values.intelligenceServer.s3.secretKey | b64enc | quote }}
+  {{- else }}
+  secret-key: {{ "" | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/intelligence/templates/server/server-config.yml
+++ b/charts/intelligence/templates/server/server-config.yml
@@ -23,5 +23,5 @@ data:
   RABBITMQ_PORT: {{ .Values.rabbitmq.service.port | quote }}
   # S3 Configuration (SeaweedFS) - Required for Intelligence
   S3_URL: {{ .Values.intelligenceServer.s3.url | default "http://seaweedfs-s3:8333" | quote }}
-  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.analytics.bucketName | default "api-metrics" | quote }}
+  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.intelligence.bucketName | default "api-metrics" | quote }}
   S3_PATH_STYLE_ACCESS: {{ .Values.intelligenceServer.s3.pathStyleAccess | default "true" | quote }}

--- a/charts/intelligence/templates/server/server-config.yml
+++ b/charts/intelligence/templates/server/server-config.yml
@@ -25,3 +25,4 @@ data:
   S3_URL: {{ .Values.intelligenceServer.s3.url | default "http://seaweedfs-s3:8333" | quote }}
   S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.intelligence.bucketName | default "api-metrics" | quote }}
   S3_PATH_STYLE_ACCESS: {{ .Values.intelligenceServer.s3.pathStyleAccess | default "true" | quote }}
+  MAX_CONCURRENT_PATCH_UPLOADS: {{ .Values.intelligenceServer.s3.maxConcurrentPatchUploads | default 5 | quote }}

--- a/charts/intelligence/templates/server/server-config.yml
+++ b/charts/intelligence/templates/server/server-config.yml
@@ -21,3 +21,7 @@ data:
   PORTAL_DATA_HOST: {{ .Values.intelligenceServer.portalDataHost| default "portal-data:8080" | quote }}
   RABBITMQ_HOST: {{ .Values.rabbitmq.host | quote }}
   RABBITMQ_PORT: {{ .Values.rabbitmq.service.port | quote }}
+  # S3 Configuration (SeaweedFS) - Required for Intelligence
+  S3_URL: {{ .Values.intelligenceServer.s3.url | default "http://seaweedfs-s3:8333" | quote }}
+  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.analytics.bucketName | default "api-metrics" | quote }}
+  S3_PATH_STYLE_ACCESS: {{ .Values.intelligenceServer.s3.pathStyleAccess | default "true" | quote }}

--- a/charts/intelligence/templates/server/server-deployment.yml
+++ b/charts/intelligence/templates/server/server-deployment.yml
@@ -354,6 +354,19 @@ spec:
             - name: PAPI_PUBLIC_PORT
               value: {{ include "intelligence.publicPort" . | quote }}
           {{- end }}
+            # S3 Credentials (SeaweedFS) - Required for Intelligence
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.deepStorage.auth.secretName | default "seaweedfs-s3-secret" }}
+                  key: {{ .Values.intelligenceServer.s3.accessKeyKey | default "admin_access_key_id" }}
+                  optional: false
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.deepStorage.auth.secretName | default "seaweedfs-s3-secret" }}
+                  key: {{ .Values.intelligenceServer.s3.secretKeyKey | default "admin_secret_access_key" }}
+                  optional: false
           envFrom:
           # Always include the main intelligence-server config
           - configMapRef:

--- a/charts/intelligence/values.yaml
+++ b/charts/intelligence/values.yaml
@@ -139,6 +139,7 @@ intelligenceServer:
     # Secret keys for accessing S3 credentials
     accessKeyKey: "admin_access_key_id"
     secretKeyKey: "admin_secret_access_key"
+    maxConcurrentPatchUploads: 5
 
 # NOTE: When this chart is used as a subchart, it requires Kafka configuration
 # for its initContainer to discover brokers. The parent chart must provide these

--- a/charts/intelligence/values.yaml
+++ b/charts/intelligence/values.yaml
@@ -69,8 +69,8 @@ global:
   deepStorage:
     auth:
       secretName: "seaweedfs-s3-secret"
-    analytics:
-      bucketName: "api-metrics"
+    intelligence:
+      bucketName: apim-patches
 
 # Intelligence Server configuration
 intelligenceServer:

--- a/charts/intelligence/values.yaml
+++ b/charts/intelligence/values.yaml
@@ -65,6 +65,12 @@ global:
   schedulerName: ""
   # Additional labels to be applied to all resources
   additionalLabels: {}
+  # Deep storage configuration (S3/SeaweedFS) - Required for Intelligence
+  deepStorage:
+    auth:
+      secretName: "seaweedfs-s3-secret"
+    analytics:
+      bucketName: "api-metrics"
 
 # Intelligence Server configuration
 intelligenceServer:
@@ -123,6 +129,16 @@ intelligenceServer:
     internalTrafficPolicy: ""
   # The host and port for the portal data service
   portalDataHost: "portal-data:8080"
+  
+  # S3 Configuration (for SeaweedFS or other S3-compatible storage)
+  s3:
+    # S3 URL (endpoint)
+    url: "http://seaweedfs-s3:8333"
+    # Use path-style access (required for SeaweedFS)
+    pathStyleAccess: true
+    # Secret keys for accessing S3 credentials
+    accessKeyKey: "admin_access_key_id"
+    secretKeyKey: "admin_secret_access_key"
 
 # NOTE: When this chart is used as a subchart, it requires Kafka configuration
 # for its initContainer to discover brokers. The parent chart must provide these

--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.4"
 description: CA API Developer Portal
 name: portal
-version: 2.3.26
+version: 2.3.27
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:
@@ -16,7 +16,7 @@ dependencies:
   repository: "file://../druid"
 - name: seaweedfs
   version: ^1.0.0
-  condition: global.deepStorage.seaweedfs
+  condition: global.deepStorage.seaweedfs,portal.intelligence.enabled
   repository: "file://../seaweedfs"
 - name: mysql
   version: 12.3.5

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -760,6 +760,59 @@ Portal Analytics
 ## Subcharts
 For Production, use an external MySQL Server.
 
+## Intelligence (APIM Intelligence)
+The Intelligence subchart provides advanced analytics and third-party agent integration capabilities.
+
+**Important Dependencies:**
+- When `portal.intelligence.enabled: true`, the following subcharts are automatically deployed:
+  - **SeaweedFS**: Required for S3-compatible storage (data persistence)
+  - **Kafka**: Required for message streaming (should be configured with 3+ replicas for production)
+- APIM service automatically receives S3 configuration environment variables when intelligence is enabled
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `portal.intelligence.enabled` | Enable Intelligence service | `false` |
+| `apim-intelligence.intelligenceServer.replicaCount` | Number of intelligence server replicas | `1` |
+| `apim-intelligence.intelligenceServer.s3.endpoint` | S3 endpoint URL (SeaweedFS) | `http://seaweedfs-s3:8333` |
+| `apim-intelligence.intelligenceServer.s3.region` | S3 region | `us-east-1` |
+| `apim-intelligence.intelligenceServer.kafka.autoDiscovery.enabled` | Enable Kafka broker auto-discovery | `true` |
+
+For detailed Intelligence configuration, see the [Intelligence Chart README](../intelligence/README.md).
+
+## SeaweedFS
+The SeaweedFS subchart provides S3-compatible object storage for analytics data and intelligence services.
+
+**Automatic Deployment:**
+- Deployed when `global.deepStorage.seaweedfs: true` OR `portal.intelligence.enabled: true`
+- Required for Intelligence service data persistence
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `global.deepStorage.seaweedfs` | Enable SeaweedFS for deep storage | `true` |
+| `global.deepStorage.enableDataMigration` | Enable data migration from Minio to SeaweedFS | `true` |
+| `global.deepStorage.analytics.bucketName` | S3 bucket name for analytics data | `api-metrics` |
+| `seaweedfs.replicaCount` | Number of SeaweedFS replicas | `1` |
+| `seaweedfs.persistence.storage.seaweedfs` | SeaweedFS PVC Size | `50Gi` |
+
+For detailed SeaweedFS configuration and migration guide, see [Minio to SeaweedFS Migration Guide](../../utils/MINIO-TO-SEAWEEDFS-MIGRATION.md).
+
+## Kafka
+The Kafka subchart provides Apache Kafka 4.0.0 in KRaft mode (Zookeeper-less) for message streaming.
+
+**Automatic Deployment:**
+- Deployed when `kafka.enabled: true`
+- Required for Intelligence service
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `kafka.enabled` | Enable Kafka subchart | `false` |
+| `kafka.kafka.replicaCount` | Number of Kafka broker replicas (3+ recommended for production) | `1` |
+| `kafka.kafka.kraft.enabled` | Enable KRaft mode (Zookeeper-less) | `true` |
+| `kafka.externalAccess.enabled` | Enable external access to Kafka brokers | `true` |
+| `kafka.externalAccess.serviceType` | Service type for external access | `LoadBalancer` |
+
+For detailed Kafka configuration, see the [Kafka Chart README](../kafka/README.md).
+
 ## Druid
 The following table lists the configured parameters of the Druid Subchart:
 

--- a/charts/portal/templates/apim/apim-config.yaml
+++ b/charts/portal/templates/apim/apim-config.yaml
@@ -33,8 +33,7 @@ data:
   INTELLIGENCE_ENABLED: "true"
   # S3 Configuration (SeaweedFS) - Only when Intelligence is enabled
   S3_URL: {{ .Values.apim.s3.url | default "http://seaweedfs-s3:8333" | quote }}
-  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.analytics.bucketName | default "api-metrics" | quote }}
-  S3_PATH_STYLE_ACCESS: {{ .Values.apim.s3.pathStyleAccess | default "true" | quote }}
+  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.intellignece.bucketName | default "apim-patches" | quote }}
 {{- else }}
   # Intelligence Feature Flag
   INTELLIGENCE_ENABLED: "false"

--- a/charts/portal/templates/apim/apim-config.yaml
+++ b/charts/portal/templates/apim/apim-config.yaml
@@ -28,6 +28,17 @@ data:
   TENANT_ID: {{ include "default-tenant-id" . | quote }}
   TSSG_PUBLIC_HOST: {{ include "tssg-public-host" . | quote }}
   TSSG_PUBLIC_PORT: {{ .Values.portal.otk.port | quote }}
+{{- if .Values.portal.intelligence.enabled }}
+  # Intelligence Feature Flag
+  INTELLIGENCE_ENABLED: "true"
+  # S3 Configuration (SeaweedFS) - Only when Intelligence is enabled
+  S3_URL: {{ .Values.apim.s3.url | default "http://seaweedfs-s3:8333" | quote }}
+  S3_PATCH_BUCKET_NAME: {{ .Values.global.deepStorage.analytics.bucketName | default "api-metrics" | quote }}
+  S3_PATH_STYLE_ACCESS: {{ .Values.apim.s3.pathStyleAccess | default "true" | quote }}
+{{- else }}
+  # Intelligence Feature Flag
+  INTELLIGENCE_ENABLED: "false"
+{{- end }}
 {{ if .Values.apim.additionalEnv }}
 {{- range $key, $val := .Values.apim.additionalEnv }}
   {{ $key }}: {{ $val | quote }}

--- a/charts/portal/templates/apim/apim-deployment.yaml
+++ b/charts/portal/templates/apim/apim-deployment.yaml
@@ -153,6 +153,21 @@ spec:
                   name: {{ .Values.tls.externalSecretName }}
                   key: keypass.txt
                   optional: false
+          {{- if .Values.portal.intelligence.enabled }}
+            # S3 Credentials (SeaweedFS) - Only when Intelligence is enabled
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.deepStorage.auth.secretName | default "seaweedfs-s3-secret" }}
+                  key: admin_access_key_id
+                  optional: false
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.deepStorage.auth.secretName | default "seaweedfs-s3-secret" }}
+                  key: admin_secret_access_key
+                  optional: false
+          {{- end }}
           envFrom:
           - configMapRef:
               name: apim-config

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -42,7 +42,7 @@ global:
   deepStorage:
     # Enable SeaweedFS for deep storage (S3-compatible)
     # IMPORTANT: This is automatically enabled when portal.intelligence.enabled is true
-    # Intelligence service requires S3 storage for data persistence
+    # Intelligence uses S3 storage as apim patches store
     seaweedfs: true
     # Set to true to create a data migration Job from Minio to SeaweedFS
     # The Job runs independently and will not block helm operations
@@ -56,6 +56,8 @@ global:
       secretName: seaweedfs-s3-secret
     analytics:
       bucketName: api-metrics
+    intelligence:
+      bucketName: apim-patches
 
 portal:
   domain: example.com
@@ -1211,6 +1213,7 @@ apim-intelligence:
       pathStyleAccess: true
       accessKeyKey: "admin_access_key_id"
       secretKeyKey: "admin_secret_access_key"
+      patchBucketName: "apim-patches"
 
 # Settings for Nginx-Ingress - https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 ingress-nginx:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -40,6 +40,9 @@ global:
     allowInsecureImages: true
 
   deepStorage:
+    # Enable SeaweedFS for deep storage (S3-compatible)
+    # IMPORTANT: This is automatically enabled when portal.intelligence.enabled is true
+    # Intelligence service requires S3 storage for data persistence
     seaweedfs: true
     # Set to true to create a data migration Job from Minio to SeaweedFS
     # The Job runs independently and will not block helm operations
@@ -59,6 +62,14 @@ portal:
   enrollNotificationEmail: noreply@mail.example.com
   analytics:
     enabled: true
+  # Intelligence feature for advanced analytics and third-party agent integration
+  # IMPORTANT: When intelligence.enabled is true:
+  #   - kafka.kafka.replicaCount should be set to 3 (recommended for production)
+  #   - seaweedfs subchart will be automatically deployed (required for S3 storage)
+  #   - APIM will receive S3 configuration environment variables
+  # Intelligence is disabled by default. Enable it for third-party agent integration.
+  intelligence:
+    enabled: false
   # Please set analytics.replicaCount to a minimum of 2
     aggregation: true
   # Specify a Gateway v9.x license file via set portal.license.value
@@ -279,6 +290,10 @@ apim:
 #           - apim
 #       topologyKey: "kubernetes.io/hostname"
   additionalEnv:
+  # S3 Configuration (SeaweedFS) - Used when intelligence is enabled
+  s3:
+    url: "http://seaweedfs-s3:8333"
+    pathStyleAccess: "true"
 
 authenticator:
   forceRedeploy: false
@@ -1190,6 +1205,12 @@ apim-intelligence:
       create: false
       maxUnavailable: ""
       minAvailable: ""
+    # S3 Configuration (SeaweedFS)
+    s3:
+      url: "http://seaweedfs-s3:8333"
+      pathStyleAccess: true
+      accessKeyKey: "admin_access_key_id"
+      secretKeyKey: "admin_secret_access_key"
 
 # Settings for Nginx-Ingress - https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 ingress-nginx:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -47,6 +47,9 @@ global:
     allowInsecureImages: true
 
   deepStorage:
+    # Enable SeaweedFS for deep storage (S3-compatible)
+    # IMPORTANT: This is automatically enabled when portal.intelligence.enabled is true
+    # Intelligence service requires S3 storage for data persistence
     seaweedfs: true
     # Set to true to create a data migration Job from Minio to SeaweedFS
     # The Job runs independently and will not block helm operations
@@ -71,6 +74,8 @@ portal:
   # Intelligence feature for advanced analytics and third-party agent integration
   # IMPORTANT: When intelligence.enabled is true:
   #   - kafka.kafka.replicaCount should be set to 3 (recommended for production)
+  #   - seaweedfs subchart will be automatically deployed (required for S3 storage)
+  #   - APIM will receive S3 configuration environment variables
   # Intelligence is disabled by default. Enable it for third-party agent integration.
   intelligence:
     enabled: false
@@ -473,6 +478,10 @@ tenantProvisioner:
 # tolerations: []
 # affinity: {}
   additionalEnv:
+  # S3 Configuration (SeaweedFS) - Used when intelligence is enabled
+  s3:
+    url: "http://seaweedfs-s3:8333"
+    pathStyleAccess: "true"
 
 image:
   dispatcher: dispatcher:5.4
@@ -1272,6 +1281,12 @@ apim-intelligence:
     # nodeSelector: {}
     # tolerations: []
     # affinity: {}
+    # S3 Configuration (SeaweedFS)
+    s3:
+      url: "http://seaweedfs-s3:8333"
+      pathStyleAccess: true
+      accessKeyKey: "admin_access_key_id"
+      secretKeyKey: "admin_secret_access_key"
 
 # Settings for Nginx-Ingress - https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx
 ingress-nginx:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -49,7 +49,7 @@ global:
   deepStorage:
     # Enable SeaweedFS for deep storage (S3-compatible)
     # IMPORTANT: This is automatically enabled when portal.intelligence.enabled is true
-    # Intelligence service requires S3 storage for data persistence
+    # Intelligence uses S3 storage as apim patches store
     seaweedfs: true
     # Set to true to create a data migration Job from Minio to SeaweedFS
     # The Job runs independently and will not block helm operations
@@ -63,6 +63,8 @@ global:
       secretName: seaweedfs-s3-secret
     analytics:
       bucketName: api-metrics
+    intelligence:
+      bucketName: apim-patches
 
 portal:
   # NOTE: domain is now set in global.domain (above) for consistency across all components


### PR DESCRIPTION
**Description of the change**

Add S3 env vars to intelligence server and conditionally to apim when intelligence is enabled.
Deploy seaweedFS if intelligence is enabled.

**Benefits**

Store apim patch files in s3 store.

**Drawbacks**

None

**Applicable issues**

None

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

