### PR TITLE
fsGroup

### DIFF
--- a/charts/gateway/templates/mysql/mysql-statefulset.yaml
+++ b/charts/gateway/templates/mysql/mysql-statefulset.yaml
@@ -205,7 +205,7 @@ spec:
       - name: custom-init-scripts
         configMap:
           {{- if and .Values.otk.enabled .Values.otk.database.useDemoDb }}
-          name: otk-db-scripts-cm
+          name: {{ .Values.mysql.initdbScriptsConfigMap | default "otk-db-scripts-cm" }}
           {{- else }}
           name: {{ .Values.mysql.initdbScriptsConfigMap | default (printf "%s-mysql-init-scripts" (include "gateway.fullname" .)) }}
           {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -1337,7 +1337,8 @@ mysql:
   # schedulerName: ""
   # priorityClassName: ""
   # terminationGracePeriodSeconds: ""
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1001
   containerSecurityContext:
     runAsUser: 1001
     runAsGroup: 1001


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**
1. deploy to gke had permission error with pvc
```
$ kubectl logs scott-nobit-gateway1-mysql-0 --namespace scott-nobit
2026-02-10 18:05:53+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.4.5-1.el9 started.
2026-02-10 18:05:54+00:00 [Note] [Entrypoint]: Initializing database files
mysqld: Can't create/write to file '/var/lib/mysql/is_writable' (OS errno 13 - Permission denied)
```
adding podSecurityContext.fsGroup fixed it.

2. otk-db-scripts-cm interpolation
We change this value even for demoDb to allow parallel multiple otk deployments in the same namespace

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

