### PR TITLE
[charts/portal] Custom domain and vanityURL

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -7,6 +7,9 @@ This Chart deploys the Layer7 API Developer Portal on a Kubernetes Cluster using
 ## Release Notes
 
 ## 2.3.19 General Updates
+- Custom Domain and VanityUrl Changes.
+
+## 2.3.19 General Updates
 - This new version of the chart makes Portal db-upgrade-portal/rbac resource configurable per customer request.
 - This new version of the chart supports API Portal 5.4
 - DB container(for testing) upgraded to support 8.4.5 MySQL version.

--- a/charts/portal/templates/dispatcher/dispatcher-config.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-config.yaml
@@ -17,11 +17,11 @@ data:
   CUSTOM_URLS_ENABLED: "true"
 {{- range .Values.dispatcher.customUrls.domains }}
 {{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
-{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "_" }}
+{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "__" }}
 {{- $certBase64 := .cert | b64enc }}
 {{- $keyBase64 := .key | b64enc }}
-  CUSTOM_DOMAIN_{{ $tenantUpper }}_{{ $domainUpper }}_CERT: {{ $certBase64 | quote }}
-  CUSTOM_DOMAIN_{{ $tenantUpper }}_{{ $domainUpper }}_KEY: {{ $keyBase64 | quote }}
+  CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_CERT: {{ $certBase64 | quote }}
+  CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_KEY: {{ $keyBase64 | quote }}
 {{- end }}
 {{- else }}
   CUSTOM_URLS_ENABLED: "false"

--- a/charts/portal/templates/dispatcher/dispatcher-config.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-config.yaml
@@ -15,14 +15,6 @@ data:
   USE_PROXY_PROTOCOL: "false"
 {{- if .Values.dispatcher.customUrls.enabled }}
   CUSTOM_URLS_ENABLED: "true"
-{{- range .Values.dispatcher.customUrls.domains }}
-{{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
-{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "__" }}
-{{- $certBase64 := .cert | b64enc }}
-{{- $keyBase64 := .key | b64enc }}
-  CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_CERT: {{ $certBase64 | quote }}
-  CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_KEY: {{ $keyBase64 | quote }}
-{{- end }}
 {{- else }}
   CUSTOM_URLS_ENABLED: "false"
 {{- end }}

--- a/charts/portal/templates/dispatcher/dispatcher-config.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-config.yaml
@@ -13,6 +13,19 @@ data:
   PORTAL_VERSION: {{ .Chart.AppVersion | quote }}
   TSSG_PUBLIC_HOST: {{ include "tssg-public-host" . | quote }}
   USE_PROXY_PROTOCOL: "false"
+{{- if .Values.dispatcher.customUrls.enabled }}
+  CUSTOM_URLS_ENABLED: "true"
+{{- range .Values.dispatcher.customUrls.domains }}
+{{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
+{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "_" }}
+{{- $certBase64 := .cert | b64enc }}
+{{- $keyBase64 := .key | b64enc }}
+  CUSTOM_DOMAIN_{{ $tenantUpper }}_{{ $domainUpper }}_CERT: {{ $certBase64 | quote }}
+  CUSTOM_DOMAIN_{{ $tenantUpper }}_{{ $domainUpper }}_KEY: {{ $keyBase64 | quote }}
+{{- end }}
+{{- else }}
+  CUSTOM_URLS_ENABLED: "false"
+{{- end }}
 {{ if .Values.dispatcher.additionalEnv }}
 {{- range $key, $val := .Values.dispatcher.additionalEnv }}
   {{ $key }}: {{ $val | quote }}

--- a/charts/portal/templates/dispatcher/dispatcher-custom-urls-secret.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-custom-urls-secret.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.dispatcher.customUrls.enabled .Values.dispatcher.customUrls.domains }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dispatcher-custom-urls-secret
+  labels:
+    app: dispatcher
+    chart: {{ template "portal.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+{{- range .Values.dispatcher.customUrls.domains }}
+{{- $tenantNormalized := .tenant | lower | replace "." "_" | replace "-" "_" }}
+{{- $domainNormalized := .domain | lower | replace "." "_" | replace "-" "__" }}
+{{- if .certFile }}
+  {{ $tenantNormalized }}_{{ $domainNormalized }}_cert: {{ .certFile | b64enc | quote }}
+{{- end }}
+{{- if .keyFile }}
+  {{ $tenantNormalized }}_{{ $domainNormalized }}_key: {{ .keyFile | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/portal/templates/dispatcher/dispatcher-custom-urls-secret.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-custom-urls-secret.yaml
@@ -14,10 +14,10 @@ data:
 {{- $tenantNormalized := .tenant | lower | replace "." "_" | replace "-" "_" }}
 {{- $domainNormalized := .domain | lower | replace "." "_" | replace "-" "__" }}
 {{- if .certFile }}
-  {{ $tenantNormalized }}_{{ $domainNormalized }}_cert: {{ .certFile | b64enc | quote }}
+  {{ $tenantNormalized }}_{{ $domainNormalized }}_cert: {{ .certFile | b64enc | b64enc | quote }}
 {{- end }}
 {{- if .keyFile }}
-  {{ $tenantNormalized }}_{{ $domainNormalized }}_key: {{ .keyFile | b64enc | quote }}
+  {{ $tenantNormalized }}_{{ $domainNormalized }}_key: {{ .keyFile | b64enc | b64enc | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
@@ -83,30 +83,30 @@ spec:
               secretKeyRef:
                 name: {{ .Values.rabbitmq.auth.secretName }}
                 key: rabbitmq-password
-{{- if and .Values.dispatcher.customUrls.enabled .Values.dispatcher.customUrls.domains }}
-{{- range .Values.dispatcher.customUrls.domains }}
-{{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
-{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "__" }}
-{{- $tenantNormalized := .tenant | lower | replace "." "_" | replace "-" "_" }}
-{{- $domainNormalized := .domain | lower | replace "." "_" | replace "-" "__" }}
-{{- if .certFile }}
+          {{- if and .Values.dispatcher.customUrls.enabled .Values.dispatcher.customUrls.domains }}
+          {{- range .Values.dispatcher.customUrls.domains }}
+          {{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
+          {{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "__" }}
+          {{- $tenantNormalized := .tenant | lower | replace "." "_" | replace "-" "_" }}
+          {{- $domainNormalized := .domain | lower | replace "." "_" | replace "-" "__" }}
+          {{- if .certFile }}
           - name: CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_CERT
             valueFrom:
               secretKeyRef:
                 name: dispatcher-custom-urls-secret
                 key: {{ $tenantNormalized }}_{{ $domainNormalized }}_cert
                 optional: false
-{{- end }}
-{{- if .keyFile }}
+          {{- end }}
+          {{- if .keyFile }}
           - name: CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_KEY
             valueFrom:
               secretKeyRef:
                 name: dispatcher-custom-urls-secret
                 key: {{ $tenantNormalized }}_{{ $domainNormalized }}_key
                 optional: false
-{{- end }}
-{{- end }}
-{{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           envFrom:
           - configMapRef:
               name: dispatcher-config

--- a/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-deployment.yaml
@@ -83,6 +83,30 @@ spec:
               secretKeyRef:
                 name: {{ .Values.rabbitmq.auth.secretName }}
                 key: rabbitmq-password
+{{- if and .Values.dispatcher.customUrls.enabled .Values.dispatcher.customUrls.domains }}
+{{- range .Values.dispatcher.customUrls.domains }}
+{{- $tenantUpper := .tenant | upper | replace "." "_" | replace "-" "_" }}
+{{- $domainUpper := .domain | upper | replace "." "_" | replace "-" "__" }}
+{{- $tenantNormalized := .tenant | lower | replace "." "_" | replace "-" "_" }}
+{{- $domainNormalized := .domain | lower | replace "." "_" | replace "-" "__" }}
+{{- if .certFile }}
+          - name: CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_CERT
+            valueFrom:
+              secretKeyRef:
+                name: dispatcher-custom-urls-secret
+                key: {{ $tenantNormalized }}_{{ $domainNormalized }}_cert
+                optional: false
+{{- end }}
+{{- if .keyFile }}
+          - name: CD_{{ $tenantUpper }}_ZZ_{{ $domainUpper }}_KEY
+            valueFrom:
+              secretKeyRef:
+                name: dispatcher-custom-urls-secret
+                key: {{ $tenantNormalized }}_{{ $domainNormalized }}_key
+                optional: false
+{{- end }}
+{{- end }}
+{{- end }}
           envFrom:
           - configMapRef:
               name: dispatcher-config

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -380,6 +380,20 @@ dispatcher:
   #   periodSeconds: 15
   #   successThreshold: 1
   #   failureThreshold: 20
+# Custom URLs configuration for Dispatcher
+# Certificates and keys should be provided via --set-file on Helm command line
+# Example:
+#   helm install portal ./charts/portal \
+#     --set dispatcher.customUrls.enabled=true \
+#     --set-file dispatcher.customUrls.domains[0].certFile=/path/to/cert.pem \
+#     --set-file dispatcher.customUrls.domains[0].keyFile=/path/to/key.pem
+  customUrls:
+    enabled: false
+    domains:
+#      - tenant: "tenant1"
+#        domain: "example.com"
+#        certFile: ""  # Set via --set-file dispatcher.customUrls.domains[0].certFile=/path/to/cert.pem
+#        keyFile: ""   # Set via --set-file dispatcher.customUrls.domains[0].keyFile=/path/to/key.pem
 
 # Additional Environment variables to be added to the Dispatcher Configmap
   additionalEnv:

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -376,19 +376,19 @@ dispatcher:
 #    key1: value
 
 # Custom URLs configuration for Dispatcher
+# Certificates and keys should be provided via --set-file on Helm command line
+# Example:
+#   helm install portal ./charts/portal \
+#     --set dispatcher.customUrls.enabled=true \
+#     --set-file dispatcher.customUrls.domains[0].certFile=/path/to/cert.pem \
+#     --set-file dispatcher.customUrls.domains[0].keyFile=/path/to/key.pem
   customUrls:
     enabled: false
     domains:
 #      - tenant: "tenant1"
 #        domain: "example.com"
-#        cert: |
-#          -----BEGIN CERTIFICATE-----
-#          ...
-#          -----END CERTIFICATE-----
-#        key: |
-#          -----BEGIN PRIVATE KEY-----
-#          ...
-#          -----END PRIVATE KEY-----
+#        certFile: ""  # Set via --set-file dispatcher.customUrls.domains[0].certFile=/path/to/cert.pem
+#        keyFile: ""   # Set via --set-file dispatcher.customUrls.domains[0].keyFile=/path/to/key.pem
 
 portalData:
   forceRedeploy: false

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -375,6 +375,21 @@ dispatcher:
   additionalSecret:
 #    key1: value
 
+# Custom URLs configuration for Dispatcher
+  customUrls:
+    enabled: false
+    domains:
+#      - tenant: "tenant1"
+#        domain: "example.com"
+#        cert: |
+#          -----BEGIN CERTIFICATE-----
+#          ...
+#          -----END CERTIFICATE-----
+#        key: |
+#          -----BEGIN PRIVATE KEY-----
+#          ...
+#          -----END PRIVATE KEY-----
+
 portalData:
   forceRedeploy: false
   replicaCount: 1


### PR DESCRIPTION
Add support for custom domain certificates in the Dispatcher component by introducing:

- Accepts certificate and key files via Helm command line using --set-file
- Creates a Kubernetes Secret to store all custom domain certificates and keys
- Updates the dispatcher template to read certificates and keys from the secret
- Maintains the same environment variable naming pattern (CD_{TENANT}\_ZZ\_{DOMAIN}\_CERT and CD_{TENANT}\_ZZ\_{DOMAIN}_KEY)
- CUSTOM_URLS_ENABLED - Boolean flag to enable/disable custom URLs feature
- CD_{TENANT}\_ZZ\_{DOMAIN}_CERT - Base64-encoded certificate for each tenant/domain combination
- CD_{TENANT}\_ZZ\_{DOMAIN}_KEY - Base64-encoded key for each tenant/domain combination
- The CD_* variables are only set when CUSTOM_URLS_ENABLED is true.

**Benefits**

Fixe [DE641541](https://rally1.rallydev.com/#/?detail=/defect/829062575183&fdp=true): Change hostname/domainname of tenant exiting portal tenant

**Drawbacks**

None.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - [DE641541](https://rally1.rallydev.com/#/?detail=/defect/829062575183&fdp=true): Change hostname/domainname of tenant exiting portal tenant

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

