### PR TITLE
[charts/portal] Added option for disabling tls on portal ingress

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "5.4"
 description: CA API Developer Portal
 name: portal
-version: 2.3.21
+version: 2.3.22
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -323,6 +323,7 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `ingress.type.kubernetes` | Create a Kubernetes Ingress Object | `true` |
 | `ingress.type.openshift` | Create Openshift Services | `false` |
 | `ingress.type.secretName` | Certificate Secret Name to be created | `dispatcher-tls` |
+| `ingress.tls` | Enable or disable tls on the ingress rule | `true` |
 | `ingress.create` | Deploy the Nginx subchart as part of this deployment. ***Note:-*** This is a third-party sub chart which is not supported/maintained by Layer7. Included only for reference/sample | `false` |
 | `ingress.class.name` | Deploy the Nginx subchart with the specified name | `nginx` |
 | `ingress.class.enabled` | Deploy the Nginx subchart with the specified name , if the flag is enabled | `true` |

--- a/charts/portal/templates/dispatcher/dispatcher-tls.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-tls.yaml
@@ -1,4 +1,4 @@
-{{if not .Values.ingress.existingSecret}}
+{{if and .Values.ingress.tls (not .Values.ingress.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,5 +17,3 @@ data:
   tls.key: {{ include "dispatcher-ssl-key" . | b64enc | quote }}
 {{ end }}
 {{ end }}
-
-  

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -26,11 +26,13 @@ metadata:
 spec:
  {{- if and (semverCompare ">=1.19-0" $kubeTargetVersion) (.Values.ingress.class.enabled) }}
   ingressClassName: {{ .Values.ingress.class.name }}
- {{- end }} 
+ {{- end }}
+ {{- if .Values.ingress.tls }}
   tls:
   - secretName: {{ .Values.ingress.secretName }}
     hosts:
     - {{ include "get-ingress-hosts" . | quote }}
+  {{- end }}
   rules:
   - host: {{ include "default-tenant-host" . | quote }}
     http:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -134,6 +134,8 @@ ingress:
   type:
     kubernetes: true
     openshift: false
+  # enable/disable tls on ingress rule
+  tls: true
   # existingSecret:
   secretName: dispatcher-tls
   ## To install ingress-nginx controller during Portal deployment set to true and see Subcharts section for configuration options
@@ -346,8 +348,8 @@ dispatcher:
 #           values:
 #           - dispatcher
 #       topologyKey: "kubernetes.io/hostname"
-# If you want to specify Probe - readiness and/or liveness probe, uncomment below sections and update. 
-# If none specified, default HTTP GET request is used for both readiness and liveness probe 
+# If you want to specify Probe - readiness and/or liveness probe, uncomment below sections and update.
+# If none specified, default HTTP GET request is used for both readiness and liveness probe
   # readinessProbe:
   #   exec:
   #     command: [sh, /opt/diagnostic/health_check.sh]

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -136,6 +136,8 @@ ingress:
   type:
     kubernetes: true
     openshift: false
+  # enable/disable tls on ingress rule
+  tls: true
 # existingSecret:
   secretName: dispatcher-tls
   ## Deploy an nginx-ingress controller as part of this deployment. See Subcharts section for configuration options


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Added option to disable tls on the portal ingress rule.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Our ingress controller already has a wildcard certificate applied to it. So we don't want to enable tls on the ingress rule.

**Drawbacks**

<!-- Describe any known limitations with your change -->
None, optional on/off toggle which keeps previous behaviour as default.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None created

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

