### PR TITLE
Fix: Operation CREATE USER failed for <username>

### DIFF
--- a/charts/portal/templates/mysql/mysql-statefulset.yaml
+++ b/charts/portal/templates/mysql/mysql-statefulset.yaml
@@ -91,16 +91,6 @@ spec:
               key: mysql-root-password
         - name: MYSQL_DATABASE
           value: {{ .Values.global.databaseName | default "portal" | quote }}
-        - name: MYSQL_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.global.databaseSecret }}
-              key: mysql-user
-        - name: MYSQL_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.global.databaseSecret }}
-              key: mysql-password
         {{- if .Values.mysql.extraEnvVars }}
         {{- toYaml .Values.mysql.extraEnvVars | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
**Description of the change**

MYSQL auto creates user if MYSQL_USER env variable exists. which is conflicting with user creation from custom-init-db scripts of our self service job.
**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

