### PR TITLE
[charts/portal] Adding flexibility to toggle TLS at k8s ingress route level

### DIFF
--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -365,7 +365,6 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `ingress.type.openshift` | Create Openshift Services | `false` |
 | `ingress.type.secretName` | Certificate Secret Name to be created | `dispatcher-tls` |
 | `ingress.tls` | Enable or disable tls on the ingress rule | `true` |
-| `ingress.tls` | Enable or disable tls on the ingress rule | `true` |
 | `ingress.create` | Deploy the Nginx subchart as part of this deployment. ***Note:-*** This is a third-party sub chart which is not supported/maintained by Layer7. Included only for reference/sample | `false` |
 | `ingress.class.name` | Deploy the Nginx subchart with the specified name | `nginx` |
 | `ingress.class.enabled` | Deploy the Nginx subchart with the specified name , if the flag is enabled | `true` |

--- a/charts/portal/README.md
+++ b/charts/portal/README.md
@@ -364,6 +364,8 @@ This section describes configurable parameters in **values.yaml**, there is also
 | `ingress.type.kubernetes` | Create a Kubernetes Ingress Object | `true` |
 | `ingress.type.openshift` | Create Openshift Services | `false` |
 | `ingress.type.secretName` | Certificate Secret Name to be created | `dispatcher-tls` |
+| `ingress.tls` | Enable or disable tls on the ingress rule | `true` |
+| `ingress.tls` | Enable or disable tls on the ingress rule | `true` |
 | `ingress.create` | Deploy the Nginx subchart as part of this deployment. ***Note:-*** This is a third-party sub chart which is not supported/maintained by Layer7. Included only for reference/sample | `false` |
 | `ingress.class.name` | Deploy the Nginx subchart with the specified name | `nginx` |
 | `ingress.class.enabled` | Deploy the Nginx subchart with the specified name , if the flag is enabled | `true` |

--- a/charts/portal/templates/dispatcher/dispatcher-tls.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-tls.yaml
@@ -1,4 +1,5 @@
-{{if not .Values.ingress.existingSecret}}
+# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
+{{if and .Values.ingress.tls (not .Values.ingress.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,5 +18,3 @@ data:
   tls.key: {{ include "dispatcher-ssl-key" . | b64enc | quote }}
 {{ end }}
 {{ end }}
-
-  

--- a/charts/portal/templates/dispatcher/dispatcher-tls.yaml
+++ b/charts/portal/templates/dispatcher/dispatcher-tls.yaml
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 {{if and .Values.ingress.tls (not .Values.ingress.existingSecret) }}
 apiVersion: v1
 kind: Secret

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 {{- $kubeTargetVersion := .Capabilities.KubeVersion.GitVersion }}
 {{ if .Values.ingress.type.kubernetes }}
 {{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}

--- a/charts/portal/templates/ingress/ingress.yaml
+++ b/charts/portal/templates/ingress/ingress.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 {{- $kubeTargetVersion := .Capabilities.KubeVersion.GitVersion }}
 {{ if .Values.ingress.type.kubernetes }}
 {{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}
@@ -26,11 +27,13 @@ metadata:
 spec:
  {{- if and (semverCompare ">=1.19-0" $kubeTargetVersion) (.Values.ingress.class.enabled) }}
   ingressClassName: {{ .Values.ingress.class.name }}
- {{- end }} 
+ {{- end }}
+ {{- if .Values.ingress.tls }}
   tls:
   - secretName: {{ .Values.ingress.secretName }}
     hosts:
     - {{ include "get-ingress-hosts" . | quote }}
+  {{- end }}
   rules:
   - host: {{ include "default-tenant-host" . | quote }}
     http:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -155,7 +155,9 @@ ingress:
   type:
     kubernetes: true
     openshift: false
-# existingSecret:
+  # enable/disable tls on ingress rule
+  tls: true
+  # existingSecret:
   secretName: dispatcher-tls
   ## Deploy an nginx-ingress controller as part of this deployment. See Subcharts section for configuration options
   ## Using other ingress controllers will work as long as they support SSL Passthrough

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -170,6 +170,8 @@ ingress:
   type:
     kubernetes: true
     openshift: false
+  # enable/disable tls on ingress rule
+  tls: true
 # existingSecret:
   secretName: dispatcher-tls
   ## Deploy an nginx-ingress controller as part of this deployment. See Subcharts section for configuration options


### PR DESCRIPTION
**Description of the change**

Verified in AKS with tls off and on.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

