### PR TITLE
Provide a set of scripts to support offline installs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Scripts for API Portal Helm charts, including image manifest generation and pull
 
 | Script | Purpose |
 |--------|---------|
-| **generate-portal-image-manifest.sh** | Given a Portal version (e.g. `5.4`), resolves the Helm chart version from the repo, pulls that chart, and extracts the image list from its `values.yaml`. Writes a manifest file (image refs only, one per line) for use with `pull-portal-images.sh`. |
+| **generate-portal-image-manifest.sh** | Given a Portal version (e.g. `5.4`), resolves the Helm chart version from the repo, pulls that chart, and extracts the image list from its `values.yaml`. Writes a manifest file whose first line identifies Portal appVersion and Helm chart version (comment), followed by image refs (one per line) for use with `pull-portal-images.sh`. |
 | **pull-portal-images.sh** | Reads a manifest file and pulls each image. Supports simple refs (`name:tag`) or full refs (`registry/repo/name:tag`). Optionally pushes to an internal registry. |
 | **extract-portal-images.sh** | Used by the generator: reads a chart `values.yaml` and prints one full image reference per line (portal core, RabbitMQ, Druid; excludes MySQL). No Python or pip required. If `druid.enabled` is false in your values, ignore the druid lines in the list. |
 | **extract-portal-images.py** | Optional Python alternative to the shell extractor; same output format. Requires PyYAML (`pip install pyyaml`). |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,48 @@
+# Scripts
+
+Scripts for API Portal Helm charts, including image manifest generation and pulling images when the cluster cannot access Docker Hub (e.g. behind a firewall).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| **generate-portal-image-manifest.sh** | Given a Portal version (e.g. `5.4`), resolves the Helm chart version from the repo, pulls that chart, and extracts the image list from its `values.yaml`. Writes a manifest file (image refs only, one per line) for use with `pull-portal-images.sh`. |
+| **pull-portal-images.sh** | Reads a manifest file and pulls each image. Supports simple refs (`name:tag`) or full refs (`registry/repo/name:tag`). Optionally pushes to an internal registry. |
+| **extract-portal-images.py** | Used by the generator: reads a chart `values.yaml` and prints one full image reference per line (portal core, RabbitMQ, Druid; excludes MySQL). |
+
+## Requirements
+
+- **Helm 3** – for `generate-portal-image-manifest.sh`
+- **Python 3** and **PyYAML** – for the generator and `extract-portal-images.py`  
+  Install: `pip install pyyaml` or `pip install -r scripts/requirements.txt`  
+  If your environment requires an activated virtualenv, create one first:  
+  `python3 -m venv .venv` then `source .venv/bin/activate` (Linux/macOS)
+- **Docker** (or Podman) – for `pull-portal-images.sh`; log in to the source registry (and internal registry if pushing)
+
+## Quick start (firewall / internal registry)
+
+1. **Generate a manifest** for the target Portal version (e.g. 5.4):
+   ```bash
+   ./scripts/generate-portal-image-manifest.sh 5.4
+   ```
+   This writes `manifest-5.4.txt` in the current directory (override with `MANIFEST_OUTPUT=/path/to/file.txt`).
+
+2. **Pull images** from that manifest:
+   ```bash
+   ./scripts/pull-portal-images.sh manifest-5.4.txt
+   ```
+
+3. **Optional:** Pull from a different source or push to an internal registry:
+   ```bash
+   SOURCE_REGISTRY=myreg.com SOURCE_REPO=portal ./scripts/pull-portal-images.sh manifest-5.4.txt
+   INTERNAL_REGISTRY=myreg.com/portal PUSH_INTERNAL=1 ./scripts/pull-portal-images.sh manifest-5.4.txt
+   ```
+
+One-liner (generate then pull):
+```bash
+./scripts/generate-portal-image-manifest.sh 5.4 && ./scripts/pull-portal-images.sh manifest-5.4.txt
+```
+
+## Upgrade path
+
+For the supported Portal upgrade path (5.1 → 5.2 → 5.3 → 5.4) and when to use these scripts, see [PORTAL_5.1_TO_5.4_UPGRADE_STEPS.md](../PORTAL_5.1_TO_5.4_UPGRADE_STEPS.md).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,15 +8,12 @@ Scripts for API Portal Helm charts, including image manifest generation and pull
 |--------|---------|
 | **generate-portal-image-manifest.sh** | Given a Portal version (e.g. `5.4`), resolves the Helm chart version from the repo, pulls that chart, and extracts the image list from its `values.yaml`. Writes a manifest file (image refs only, one per line) for use with `pull-portal-images.sh`. |
 | **pull-portal-images.sh** | Reads a manifest file and pulls each image. Supports simple refs (`name:tag`) or full refs (`registry/repo/name:tag`). Optionally pushes to an internal registry. |
-| **extract-portal-images.py** | Used by the generator: reads a chart `values.yaml` and prints one full image reference per line (portal core, RabbitMQ, Druid; excludes MySQL). |
+| **extract-portal-images.sh** | Used by the generator: reads a chart `values.yaml` and prints one full image reference per line (portal core, RabbitMQ, Druid; excludes MySQL). No Python or pip required. If `druid.enabled` is false in your values, ignore the druid lines in the list. |
+| **extract-portal-images.py** | Optional Python alternative to the shell extractor; same output format. Requires PyYAML (`pip install pyyaml`). |
 
 ## Requirements
 
-- **Helm 3** – for `generate-portal-image-manifest.sh`
-- **Python 3** and **PyYAML** – for the generator and `extract-portal-images.py`  
-  Install: `pip install pyyaml` or `pip install -r scripts/requirements.txt`  
-  If your environment requires an activated virtualenv, create one first:  
-  `python3 -m venv .venv` then `source .venv/bin/activate` (Linux/macOS)
+- **Helm 3** – for `generate-portal-image-manifest.sh` (image extraction uses the shell script; no Python or pip required)
 - **Docker** (or Podman) – for `pull-portal-images.sh`; log in to the source registry (and internal registry if pushing)
 
 ## Quick start (firewall / internal registry)

--- a/scripts/extract-portal-images.py
+++ b/scripts/extract-portal-images.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""
+Read a Portal chart values.yaml and print one full image reference per line
+(portal core, RabbitMQ, Druid). Excludes MySQL. Used by pull-portal-images.sh.
+
+Requires: PyYAML (pip install pyyaml).
+"""
+import sys
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: extract-portal-images.py <path-to-values.yaml>", file=sys.stderr)
+        sys.exit(1)
+    path = sys.argv[1]
+    try:
+        with open(path) as f:
+            values = yaml.safe_load(f)
+    except Exception as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not values:
+        sys.exit(0)
+
+    prefix = (values.get("global") or {}).get("portalRepository") or "caapim/"
+    if not prefix.endswith("/"):
+        prefix = prefix + "/"
+
+    refs = []
+
+    # Portal core images (top-level image.*)
+    image_block = values.get("image") or {}
+    for _key, value in image_block.items():
+        if isinstance(value, str) and value:
+            refs.append(prefix + value)
+
+    # RabbitMQ
+    rmq = (values.get("rabbitmq") or {}).get("image") or {}
+    if rmq:
+        reg = rmq.get("registry") or "caapim"
+        repo = rmq.get("repository") or "message-broker"
+        tag = rmq.get("tag") or "latest"
+        refs.append(f"{reg}/{repo}:{tag}")
+
+    # Druid (only if enabled)
+    druid = values.get("druid") or {}
+    if druid.get("enabled", True):
+        druid_images = druid.get("image") or {}
+        for _key, value in druid_images.items():
+            if isinstance(value, str) and value:
+                refs.append(prefix + value)
+
+    for r in refs:
+        print(r)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract-portal-images.sh
+++ b/scripts/extract-portal-images.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Read a Portal chart values.yaml and print one full image reference per line
+# (portal core, RabbitMQ, Druid). Excludes MySQL. No Python or pip required.
+# Alternative to extract-portal-images.py for sites where Python/PyYAML is not available.
+#
+# Usage: extract-portal-images.sh <path-to-values.yaml>
+#
+# Output format matches extract-portal-images.py so it can be used interchangeably.
+# Two awk passes: (1) portal images, (2) RabbitMQ + Druid together. This avoids
+# state interactions that on some systems prevent druid from outputting.
+#
+
+set -e
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: extract-portal-images.sh <path-to-values.yaml>" >&2
+  exit 1
+fi
+
+VALUES_FILE="$1"
+if [[ ! -f "$VALUES_FILE" ]]; then
+  echo "Error: file not found: $VALUES_FILE" >&2
+  exit 1
+fi
+
+# Prefix (global.portalRepository); default caapim/
+PREFIX="caapim/"
+found=$(grep -E '[[:space:]]*portalRepository:' "$VALUES_FILE" | grep -v '^[[:space:]]*#' | head -1)
+if [[ -n "$found" ]]; then
+  PREFIX=$(echo "$found" | sed -E 's/^[[:space:]]*portalRepository:[[:space:]]*//' | tr -d '"' | tr -d "'" | tr -d '\n\r')
+fi
+[[ "$PREFIX" =~ /$ ]] || PREFIX="${PREFIX}/"
+
+# Pass 1: Portal core images only (top-level image block)
+awk -v prefix="$PREFIX" '
+  /^image:[[:space:]]*$/ { in_block=1; next }
+  in_block && (/^[a-zA-Z]/ || /^#/) { in_block=0 }
+  in_block && /^  [a-zA-Z0-9_-]+:[[:space:]]+.+:.+/ {
+    sub(/^  [a-zA-Z0-9_-]+:[[:space:]]+/, "")
+    if ($0 != "" && $0 !~ /^#/) print prefix $0
+  }
+' < "$VALUES_FILE"
+
+# Pass 2: RabbitMQ only
+awk '
+  /^rabbitmq:[[:space:]]*$/ { in_rmq=1; reg="caapim"; repo="message-broker"; tag="latest"; next }
+  in_rmq && /^[a-zA-Z]/ { in_rmq=0 }
+  in_rmq && /^[[:space:]]+image:[[:space:]]*$/ { in_rmq_img=1; next }
+  in_rmq && in_rmq_img && /^[[:space:]]+[a-zA-Z]+:[[:space:]]*$/ && $0 !~ /image/ { print reg "/" repo ":" tag; in_rmq_img=0 }
+  in_rmq && in_rmq_img && /^[[:space:]]+registry:[[:space:]]/ { sub(/^[[:space:]]+registry:[[:space:]]*/, ""); gsub(/["'\'']/, ""); reg=$0 }
+  in_rmq && in_rmq_img && /^[[:space:]]+repository:[[:space:]]/ { sub(/^[[:space:]]+repository:[[:space:]]*/, ""); gsub(/["'\'']/, ""); repo=$0 }
+  in_rmq && in_rmq_img && /^[[:space:]]+tag:[[:space:]]/ { sub(/^[[:space:]]+tag:[[:space:]]*/, ""); gsub(/["'\'']/, ""); tag=$0 }
+  END { if (in_rmq && in_rmq_img) print reg "/" repo ":" tag }
+' < "$VALUES_FILE"
+
+# Pass 3: Druid only (if druid.enabled is false in your values, ignore the druid lines in the list)
+awk -v prefix="$PREFIX" '
+  /^druid:[[:space:]]*$/ { in_druid=1; next }
+  in_druid && /^[a-zA-Z]/ { in_druid=0 }
+  in_druid && /^  image:[[:space:]]*$/ { in_druid_img=1; next }
+  in_druid && in_druid_img && /^  [a-zA-Z]+:[[:space:]]*$/ && $0 !~ /image/ { in_druid_img=0 }
+  in_druid && in_druid_img && /^    [a-zA-Z0-9_-]+:[[:space:]]+.+:.+/ {
+    sub(/^[[:space:]]+[a-zA-Z0-9_-]+:[[:space:]]+/, "")
+    if ($0 != "" && $0 !~ /^#/) print prefix $0
+  }
+' < "$VALUES_FILE"

--- a/scripts/generate-portal-image-manifest.sh
+++ b/scripts/generate-portal-image-manifest.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Copyright © 2025 Broadcom Inc. and its subsidiaries. All Rights Reserved.
+#
+# AI assistance has been used to generate some or all contents of this file.
+# That includes, but is not limited to, new code, modifying existing code, stylistic edits.
 #
 # Generate an image manifest for a given Portal version by resolving the
 # chart version (appVersion match), pulling that chart, and extracting

--- a/scripts/generate-portal-image-manifest.sh
+++ b/scripts/generate-portal-image-manifest.sh
@@ -91,6 +91,6 @@ fi
 echo "Extracting image list from values.yaml..." >&2
 {
   echo "# Portal appVersion: ${PORTAL_VERSION} | Helm chart version: ${chart_version}"
-  "${SCRIPT_DIR}/extract-portal-images.sh" "$values_file"
+  "${SCRIPT_DIR}/extract-portal-images.sh" "$values_file" | sort -u
 } > "$MANIFEST_OUTPUT"
 echo "Manifest written to ${MANIFEST_OUTPUT} (Portal ${PORTAL_VERSION}, chart ${chart_version})" >&2

--- a/scripts/generate-portal-image-manifest.sh
+++ b/scripts/generate-portal-image-manifest.sh
@@ -5,7 +5,7 @@
 # image refs from its values.yaml. Writes only image lines to a file
 # (one full image reference per line) for use with pull-portal-images.sh.
 #
-# Prerequisites: Helm 3, Python 3, PyYAML (pip install pyyaml).
+# Prerequisites: Helm 3.
 #
 # Usage:
 #   ./scripts/generate-portal-image-manifest.sh 5.4
@@ -81,17 +81,7 @@ if [[ ! -f "$values_file" ]]; then
   exit 1
 fi
 
-# Require Python + PyYAML for extractor
-if ! command -v python3 &>/dev/null; then
-  echo "Error: python3 not found. Required for image extraction." >&2
-  exit 1
-fi
-if ! python3 -c "import yaml" 2>/dev/null; then
-  echo "Error: PyYAML required. Install with: pip install pyyaml" >&2
-  exit 1
-fi
-
 # Write only image refs (one per line) to manifest file
 echo "Extracting image list from values.yaml..." >&2
-"${SCRIPT_DIR}/extract-portal-images.py" "$values_file" > "$MANIFEST_OUTPUT"
+"${SCRIPT_DIR}/extract-portal-images.sh" "$values_file" > "$MANIFEST_OUTPUT"
 echo "Manifest written to ${MANIFEST_OUTPUT}" >&2

--- a/scripts/generate-portal-image-manifest.sh
+++ b/scripts/generate-portal-image-manifest.sh
@@ -2,8 +2,9 @@
 #
 # Generate an image manifest for a given Portal version by resolving the
 # chart version (appVersion match), pulling that chart, and extracting
-# image refs from its values.yaml. Writes only image lines to a file
-# (one full image reference per line) for use with pull-portal-images.sh.
+# image refs from its values.yaml. Writes a manifest file: first line is a
+# comment with Portal appVersion and Helm chart version; remaining lines are
+# image refs (one per line) for use with pull-portal-images.sh.
 #
 # Prerequisites: Helm 3.
 #
@@ -14,7 +15,8 @@
 #   MANIFEST_OUTPUT=/path/to/my-manifest.txt ./scripts/generate-portal-image-manifest.sh 5.4
 #
 # Output: manifest file (default manifest-<version>.txt in current directory).
-# All progress messages go to stderr so the file contains only image refs.
+# First line: "# Portal appVersion: X.Y | Helm chart version: A.B.C". Rest: image refs.
+# All progress messages go to stderr.
 #
 
 set -e
@@ -27,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 usage() {
   echo "Usage: $0 <portal-version> | PORTAL_VERSION=<version> $0" >&2
   echo "  Example: $0 5.4" >&2
-  echo "  Writes manifest to manifest-<version>.txt (or MANIFEST_OUTPUT). Only image refs in file." >&2
+  echo "  Writes manifest to manifest-<version>.txt (or MANIFEST_OUTPUT); first line = version comment, rest = image refs." >&2
   exit 1
 }
 
@@ -81,7 +83,10 @@ if [[ ! -f "$values_file" ]]; then
   exit 1
 fi
 
-# Write only image refs (one per line) to manifest file
+# Write manifest: first line identifies Portal and Helm chart version, then image refs (one per line)
 echo "Extracting image list from values.yaml..." >&2
-"${SCRIPT_DIR}/extract-portal-images.sh" "$values_file" > "$MANIFEST_OUTPUT"
-echo "Manifest written to ${MANIFEST_OUTPUT}" >&2
+{
+  echo "# Portal appVersion: ${PORTAL_VERSION} | Helm chart version: ${chart_version}"
+  "${SCRIPT_DIR}/extract-portal-images.sh" "$values_file"
+} > "$MANIFEST_OUTPUT"
+echo "Manifest written to ${MANIFEST_OUTPUT} (Portal ${PORTAL_VERSION}, chart ${chart_version})" >&2

--- a/scripts/generate-portal-image-manifest.sh
+++ b/scripts/generate-portal-image-manifest.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Generate an image manifest for a given Portal version by resolving the
+# chart version (appVersion match), pulling that chart, and extracting
+# image refs from its values.yaml. Writes only image lines to a file
+# (one full image reference per line) for use with pull-portal-images.sh.
+#
+# Prerequisites: Helm 3, Python 3, PyYAML (pip install pyyaml).
+#
+# Usage:
+#   ./scripts/generate-portal-image-manifest.sh 5.4
+#   ./scripts/generate-portal-image-manifest.sh 5.3.3.1
+#   PORTAL_VERSION=5.4 ./scripts/generate-portal-image-manifest.sh
+#   MANIFEST_OUTPUT=/path/to/my-manifest.txt ./scripts/generate-portal-image-manifest.sh 5.4
+#
+# Output: manifest file (default manifest-<version>.txt in current directory).
+# All progress messages go to stderr so the file contains only image refs.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${HELM_REPO_NAME:=layer7}"
+: "${HELM_REPO_URL:=https://caapim.github.io/apim-charts/}"
+: "${CHART_BASE_DIR:=.}"
+
+usage() {
+  echo "Usage: $0 <portal-version> | PORTAL_VERSION=<version> $0" >&2
+  echo "  Example: $0 5.4" >&2
+  echo "  Writes manifest to manifest-<version>.txt (or MANIFEST_OUTPUT). Only image refs in file." >&2
+  exit 1
+}
+
+PORTAL_VERSION="${1:-${PORTAL_VERSION:-}}"
+if [[ -z "$PORTAL_VERSION" ]]; then
+  usage
+fi
+
+# Output file: only image lines written here
+: "${MANIFEST_OUTPUT:=manifest-${PORTAL_VERSION}.txt}"
+
+# Ensure Helm repo (suppress all add/update output so nothing leaks to manifest)
+helm repo add "${HELM_REPO_NAME}" "${HELM_REPO_URL}" >/dev/null 2>&1 || true
+helm repo update >/dev/null 2>&1
+
+# Find chart version where APP VERSION equals requested Portal version (take first = highest chart)
+chart_version=$(helm search repo "${HELM_REPO_NAME}/portal" --versions |
+  awk -v pv="$PORTAL_VERSION" '$3 == pv { print $2; exit }')
+
+if [[ -z "$chart_version" ]]; then
+  echo "Error: No chart found with appVersion ${PORTAL_VERSION}. Run: helm search repo ${HELM_REPO_NAME}/portal --versions" >&2
+  exit 1
+fi
+
+echo "Helm Chart version for Portal ${PORTAL_VERSION}: ${chart_version}" >&2
+
+# Pull chart archive
+mkdir -p "${CHART_BASE_DIR}"
+tgz="${CHART_BASE_DIR}/portal-${chart_version}.tgz"
+chart_dir="${CHART_BASE_DIR}/portal-${chart_version}"
+
+if [[ ! -f "$tgz" ]]; then
+  echo "Pulling ${chart_version} chart and expanding to: ${chart_dir}" >&2
+  helm pull "${HELM_REPO_NAME}/portal" --version "${chart_version}" --destination "${CHART_BASE_DIR}"
+fi
+if [[ ! -f "$tgz" ]]; then
+  echo "Error: chart archive not found at ${tgz}" >&2
+  exit 1
+fi
+
+# Extract to versioned directory if needed
+if [[ ! -f "${chart_dir}/values.yaml" ]]; then
+  echo "Expanding chart to: ${chart_dir}" >&2
+  mkdir -p "${chart_dir}"
+  tar -xzf "$tgz" -C "${chart_dir}" --strip-components=1
+fi
+
+values_file="${chart_dir}/values.yaml"
+if [[ ! -f "$values_file" ]]; then
+  echo "Error: values.yaml not found at ${values_file}" >&2
+  exit 1
+fi
+
+# Require Python + PyYAML for extractor
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 not found. Required for image extraction." >&2
+  exit 1
+fi
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "Error: PyYAML required. Install with: pip install pyyaml" >&2
+  exit 1
+fi
+
+# Write only image refs (one per line) to manifest file
+echo "Extracting image list from values.yaml..." >&2
+"${SCRIPT_DIR}/extract-portal-images.py" "$values_file" > "$MANIFEST_OUTPUT"
+echo "Manifest written to ${MANIFEST_OUTPUT}" >&2

--- a/scripts/pull-portal-images.sh
+++ b/scripts/pull-portal-images.sh
@@ -98,7 +98,10 @@ echo "PUSH_INTERNAL=${PUSH_INTERNAL} INTERNAL_REGISTRY=${INTERNAL_REGISTRY}"
 echo "---"
 
 while IFS= read -r line || [[ -n "$line" ]]; do
-  [[ -z "$(echo "$line" | tr -d '\r')" ]] && continue
+  line=$(echo "$line" | tr -d '\r')
+  [[ -z "$line" ]] && continue
+  # Skip comment lines (e.g. "# Portal appVersion: 5.4 | Helm chart version: 2.3.21")
+  [[ "$line" == \#* ]] && continue
   pull_one "$line"
 done < "$MANIFEST_FILE"
 

--- a/scripts/pull-portal-images.sh
+++ b/scripts/pull-portal-images.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Pull Portal images listed in a manifest file. Each line is one image reference:
+# - Full ref: registry/repo/name:tag (used as-is for pull).
+# - Simple ref: name:tag (prefixed with SOURCE_REGISTRY/SOURCE_REPO, or caapim/ if unset).
+# Optionally tag and push to an internal registry.
+#
+# Prerequisites: Docker (or Podman). Login to source registry; if PUSH_INTERNAL=1, login to internal registry.
+#
+# Usage:
+#   ./scripts/pull-portal-images.sh manifest.txt
+#   ./scripts/pull-portal-images.sh <(./scripts/generate-portal-image-manifest.sh 5.4)
+#   MANIFEST_FILE=manifest.txt SOURCE_REGISTRY=myreg.com SOURCE_REPO=portal ./scripts/pull-portal-images.sh
+#   MANIFEST_FILE=manifest.txt INTERNAL_REGISTRY=myreg.com/portal PUSH_INTERNAL=1 ./scripts/pull-portal-images.sh
+#
+
+set -e
+
+# Manifest file (path as first argument or MANIFEST_FILE env)
+MANIFEST_FILE="${1:-${MANIFEST_FILE:-}}"
+
+# Optional: prefix for simple refs (name:tag). If unset, "caapim/" is used for Docker Hub.
+: "${SOURCE_REGISTRY:=}"
+: "${SOURCE_REPO:=}"
+
+# Optional: push to internal registry after pull
+: "${PUSH_INTERNAL:=0}"
+: "${INTERNAL_REGISTRY:=}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+pull_count=0
+fail_count=0
+
+usage() {
+  echo "Usage: $0 <manifest-file> | MANIFEST_FILE=<path> $0" >&2
+  echo "  Manifest: one image ref per line (full ref or name:tag)." >&2
+  echo "  Generate manifest: ./scripts/generate-portal-image-manifest.sh 5.4 > manifest.txt" >&2
+  exit 1
+}
+
+# Resolve ref for pull: if line contains "/", use as-is; else prefix with SOURCE_REGISTRY/SOURCE_REPO or caapim/
+resolve_ref() {
+  local line="$1"
+  line=$(echo "$line" | tr -d '\r')
+  if [[ -z "$line" ]]; then
+    return
+  fi
+  if [[ "$line" == */* ]]; then
+    echo "$line"
+    return
+  fi
+  # Simple ref (name:tag)
+  if [[ -n "$SOURCE_REGISTRY" && -n "$SOURCE_REPO" ]]; then
+    echo "${SOURCE_REGISTRY}/${SOURCE_REPO}/${line}"
+  else
+    echo "caapim/${line}"
+  fi
+}
+
+pull_one() {
+  local ref="$1"
+  local pull_ref
+  pull_ref="$(resolve_ref "$ref")"
+  [[ -z "$pull_ref" ]] && return
+  if docker pull "$pull_ref" 2>/dev/null; then
+    echo "[OK] $pull_ref"
+    (( pull_count++ )) || true
+    if [[ "$PUSH_INTERNAL" == "1" && -n "$INTERNAL_REGISTRY" ]]; then
+      local name_tag="${pull_ref##*/}"
+      local internal_ref="${INTERNAL_REGISTRY}/${name_tag}"
+      docker tag "$pull_ref" "$internal_ref"
+      if docker push "$internal_ref" 2>/dev/null; then
+        echo "[PUSHED] $internal_ref"
+      else
+        echo "[WARN] Push failed: $internal_ref"
+        (( fail_count++ )) || true
+      fi
+    fi
+  else
+    echo "[FAIL] $pull_ref"
+    (( fail_count++ )) || true
+  fi
+}
+
+# --- Main ---
+if [[ -z "$MANIFEST_FILE" ]]; then
+  usage
+fi
+
+if [[ ! -f "$MANIFEST_FILE" && ! -p "$MANIFEST_FILE" ]]; then
+  echo "Error: manifest file not found: ${MANIFEST_FILE}" >&2
+  exit 1
+fi
+
+echo "Portal image pull (manifest=${MANIFEST_FILE})"
+echo "SOURCE_REGISTRY=${SOURCE_REGISTRY:-<default: caapim/>} SOURCE_REPO=${SOURCE_REPO:-}"
+echo "PUSH_INTERNAL=${PUSH_INTERNAL} INTERNAL_REGISTRY=${INTERNAL_REGISTRY}"
+echo "---"
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  [[ -z "$(echo "$line" | tr -d '\r')" ]] && continue
+  pull_one "$line"
+done < "$MANIFEST_FILE"
+
+echo "--- Done: $pull_count pulled, $fail_count failures ---"
+exit $fail_count

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+# For scripts that need YAML parsing (e.g. extract-portal-images.py, used by pull-portal-images.sh)
+pyyaml>=5.4


### PR DESCRIPTION
**Description of the change**

This is a POC that should be considered a work in progress.  It provides a set of scripts that support customers who cannot pull images directly from docker.io by : 

1. For a given Portal version, create a manifest file that identifies the set of images and tags that are required for that version of Portal
2. Use the manifest to pull the required images and optionally upload to a targeted private repo.

**Benefits**

This is intended to make it easier for customers to pull the correct images for a given portal release.   Of note, the image tags for a given version of Portal do not necessarily match the Portal version. As an example, for Portal 5.3.2.1, only dispatcher and portal-data use a 5.3.2.1 tag.  All other images use 5.3.2. 

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

