### PR TITLE
[charts/portal] US1077326 : installing kafka by default along with other default portal containers

### DIFF
--- a/charts/portal/Chart.yaml
+++ b/charts/portal/Chart.yaml
@@ -27,7 +27,6 @@ dependencies:
   repository: "file://../seaweedfs"
 - name: kafka
   version: ^1.0.0
-  condition: kafka.enabled
   repository: "file://../kafka"
 - name: ingress-nginx
   repository: "https://kubernetes.github.io/ingress-nginx/"


### PR DESCRIPTION
**Description of the change**

 installing kafka by default along with other default portal containers

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). - need to do
- [] Variables are documented in the README.md -  - need to do
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)

