### PR TITLE
to include h2 option

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.1"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.1.1
+version: 3.1.2
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -8,7 +8,7 @@ The Bitnami subCharts have now been fully removed from the Gateway Helm Chart. P
 The included MySQL Statefulset is enabled by default to make trying this chart out easier. ***It is not supported or recommended for production.*** Layer7 assumes that you are deploying a Gateway solution to a Kubernetes environment with an external MySQL database.
 
 ## Release notes
-- Current Chart Version 3.1.1
+- Current Chart Version 3.1.2
 
   - Please review release notes [here](./release-notes.md)
 

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -648,6 +648,10 @@ database:
   # severe/warning/info/fine(debug)/off
   liquibaseLogLevel: "off"
   name: ssg
+  # Embedded database type selection. Leave empty to use the default (derby).
+  # Set to "h2" to use the H2 embedded database. Requires database.enabled: false.
+  # type: "h2"
+  type: ""
 
 ## If loading a TLS Key/Pair
 # This key will become the default ssl key. Can only have one.

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,6 +35,9 @@ data:
   SSG_DATABASE_JDBC_URL: {{ .Values.database.jdbcURL }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- if .Values.database.type }}
+  SSG_DATABASE_TYPE: {{ .Values.database.type | lower | quote }}
 {{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}
   EXTRA_JAVA_ARGS: {{ template "gateway.javaArgs" . }} -Dcom.l7tech.server.extension.sharedCounterProvider=externalhazelcast -Dcom.l7tech.server.extension.sharedKeyValueStoreProvider=externalhazelcast -Dcom.l7tech.server.extension.sharedClusterInfoProvider=externalhazelcast

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
 {{- if and (not .Values.disklessConfig.enabled) (not .Values.disklessConfig.existingSecret.name) (not .Values.disklessConfig.setSecretByInitContainer) }}
 apiVersion: v1
 kind: Secret
@@ -33,7 +34,11 @@ stringData:
     node.db.config.main.user={{ .Values.database.username }}
     node.db.config.main.pass={{ .Values.database.password }}
     {{- else }}
+    {{- if and .Values.database.type (eq (.Values.database.type | lower) "h2") }}
+    node.db.type=h2
+    {{- else }}
     node.db.type=derby
+    {{- end }}
     node.db.config.main.user={{ default "gateway" .Values.database.username }}
     {{- end }}
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -646,6 +646,10 @@ database:
   # severe/warning/info/fine(debug)/off
   liquibaseLogLevel: "off"
   name: ssg
+  # Embedded database type selection. Leave empty to use the default (derby).
+  # Set to "h2" to use the H2 embedded database. Requires database.enabled: false.
+  # type: "h2"
+  type: ""
 
 ## If loading a TLS Key/Pair
 # This key will become the default ssl key. Can only have one.


### PR DESCRIPTION
**Description of the change**

Adds a new optional `database.type` field to the Gateway Helm chart `values.yaml` and `production-values.yaml`. When set to `"h2"`, the chart injects `SSG_DATABASE_TYPE=h2` into the Gateway container, enabling the H2 embedded database. This surfaces an existing capability in the Gateway container (`entrypoint.sh`) that was previously only configurable by passing the environment variable directly via `additionalEnv`.

**Benefits**

- Customers can switch to the H2 embedded database through a standard Helm values field, without needing `additionalEnv` workarounds.
- Zero impact on existing deployments — the field defaults to empty and no `SSG_DATABASE_TYPE` is injected, preserving current Derby/MySQL behaviour.
- Misconfigurations (e.g. setting `type: h2` alongside a JDBC URL) produce clear error messages at container startup via existing entrypoint guards.

**How to use**

To enable H2, set the following in your `values.yaml`:

```yaml
database:
  enabled: false
  create: false
  type: "h2"
```

To continue using Derby (default) or MySQL, no change is required. Omit `type` or leave it empty.

**Drawbacks**

- Helm-level validation for conflicting combinations (e.g. `type: h2` with `database.enabled: true`) is not enforced at install time; misconfigurations are caught at container boot by the entrypoint.

**Applicable issues**

  - fixes #

**Additional information**

The Gateway container `entrypoint.sh` already supported H2 via `SSG_DATABASE_TYPE=h2`. This chart change simply exposes that knob through the standard values interface. Both `values.yaml` and `production-values.yaml` have been updated to keep the two files in sync.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [X] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

