### PR TITLE
Add db migration job to update the Gateway db schema.

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -183,6 +183,11 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `database.password`          | Database Password | `mypassword` |
 | `database.liquibaseLogLevel`          | Liquibase log level | `off`  |
 | `database.name`          | Database name | `ssg`  |
+| `database.migrationJob.enabled`          | Enable a pre-upgrade database migration job. If enabled, any database proxies should be avoided and configure database.migrationJob.jdbcUrl to connect to the single writer endpoint. | `false`  |
+| `database.migrationJob.jdbcUrl`          | Mandatory JDBC URL for the migration job to connect directly to the single writer endpoint. | `nil`  |
+| `database.migrationJob.hookWeight`          | Helm hook weight for the migration job | `"-5"`  |
+| `database.migrationJob.annotations`          | Annotations for the migration job resource | `{}`  |
+| `database.migrationJob.podAnnotations`          | Annotations for the migration job pod | `{}`  |
 | `tls.useSignedCertificates`          | Enable/Disable use of your own TLS Certificate, this ovverides the Gateway's defaultSSLKey | `false` |
 | `tls.existingSecretName`          | Existing Secret that contains TLS p12 container and pass, see values.yaml for what must be included | `commented out` |
 | `tls.key`          | p12 container - this can be set with --set-file tls.key=/path/to/tls.p12 | `nil`  |

--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -648,6 +648,19 @@ database:
   # severe/warning/info/fine(debug)/off
   liquibaseLogLevel: "off"
   name: ssg
+  # Configure a pre-upgrade database migration job.
+  # This is useful when connecting to the database via a proxy with connection multiplexing
+  # as it allows the upgrade to connect directly to the primary node (by overriding jdbcUrl)
+  # before the live cluster is upgraded.
+  migrationJob:
+    enabled: false
+    # Mandatory: Provide the direct primary JDBC URL to bypass proxies here
+    jdbcUrl: ""
+    # Optional: Annotations for the Job resource
+    annotations: {}
+    # Optional: Annotations for the Pod
+    podAnnotations: {}
+    hookWeight: "-5"
 
 ## If loading a TLS Key/Pair
 # This key will become the default ssl key. Can only have one.

--- a/charts/gateway/templates/db-migration-job.yaml
+++ b/charts/gateway/templates/db-migration-job.yaml
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Broadcom Inc. and its subsidiaries. All Rights Reserved.
+{{- if .Values.database.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "gateway.fullname" . }}-db-migration
+  annotations:
+    chartversion: {{ .Chart.AppVersion | quote }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": {{ .Values.database.migrationJob.hookWeight | quote }}
+    {{- if .Values.database.migrationJob.annotations }}
+    {{- range $key, $val := .Values.database.migrationJob.annotations }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+    {{- end }}
+  labels:
+    app: {{ template "gateway.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: {{ template "gateway.fullname" . }}-db-migration
+        release: {{ .Release.Name }}
+      {{- if .Values.database.migrationJob.podAnnotations }}
+      annotations: {{- toYaml .Values.database.migrationJob.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.imagePullSecret.enabled }}
+      imagePullSecrets:
+        - name: {{ template "gateway.imagePullSecret" . }}
+      {{- end }}
+      containers:
+        - name: db-migration
+          image: {{.Values.image.registry}}/{{.Values.image.repository}}:{{.Values.image.tag}}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              cp /opt/docker/entrypoint.sh /tmp/entrypoint.sh
+              sed -i 's/^startGateway$/#startGateway/' /tmp/entrypoint.sh
+              /tmp/entrypoint.sh
+          envFrom:
+            - configMapRef:
+                name: {{ template "gateway.fullname" . }}-configmap
+            - secretRef:
+                name: {{ template "gateway.secretName" . }}
+          env:
+            - name: SSG_DATABASE_JDBC_URL
+              value: {{ required "A direct primary database JDBC URL (database.migrationJob.jdbcUrl) is REQUIRED when the migration job is enabled to bypass proxies." .Values.database.migrationJob.jdbcUrl | quote }}
+          volumeMounts:
+            - name: {{ template "gateway.fullname" . }}-license-xml
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/license/license.xml
+              subPath: license.xml
+            {{- if (not .Values.disklessConfig.enabled) }}
+            {{- if (not .Values.disklessConfig.setSecretByInitContainer) }}
+            - name: {{ template "gateway.fullname" . }}-node-properties
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
+              subPath: node.properties
+            {{- else }}
+            - name: shared-secret
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
+              subPath: node.properties
+            {{- end }}
+            {{- end }}
+      volumes:
+        - name: {{ template "gateway.fullname" . }}-license-xml
+          secret:
+            secretName: {{ template "gateway.license" . }}
+            items:
+            - key: license
+              path: license.xml
+      {{- if and (not .Values.disklessConfig.enabled) (not .Values.disklessConfig.setSecretByInitContainer) }}
+        - name: {{ template "gateway.fullname" . }}-node-properties
+          {{- if .Values.disklessConfig.existingSecret.csi }}
+          csi: {{ toYaml .Values.disklessConfig.existingSecret.csi | nindent 12 }}
+          {{- else }}
+          secret:
+            secretName: {{ template "gateway.node.properties" . }}
+            items:
+            - key: node.properties
+              path: node.properties
+          {{- end }}
+      {{- end }}
+      restartPolicy: "Never"
+{{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -646,6 +646,19 @@ database:
   # severe/warning/info/fine(debug)/off
   liquibaseLogLevel: "off"
   name: ssg
+  # Configure a pre-upgrade database migration job.
+  # This is useful when connecting to the database via a proxy with connection multiplexing
+  # as it allows the upgrade to connect directly to the primary node (by overriding jdbcUrl)
+  # before the live cluster is upgraded.
+  migrationJob:
+    enabled: false
+    # Mandatory: Provide the direct primary JDBC URL to bypass proxies here
+    jdbcUrl: ""
+    # Optional: Annotations for the Job resource
+    annotations: {}
+    # Optional: Annotations for the Pod
+    podAnnotations: {}
+    hookWeight: "-5"
 
 ## If loading a TLS Key/Pair
 # This key will become the default ssl key. Can only have one.


### PR DESCRIPTION
**Description of the change**

Introduces a new pre-upgrade Kubernetes Job (db-migration-job.yaml) to the Gateway Helm chart. This job spins up a single Gateway instance ahead of the main deployment to execute Liquibase database schema upgrades using the newly implemented session locking mechanism (L7SessionLockService). This PR adds the necessary feature toggles (database.migrationJob.enabled) and the required JDBC URL override parameter (database.migrationJob.jdbcUrl) to values.yaml and production-values.yaml. It also updates the README.md and provides comprehensive architectural documentation in a new docs/db-migration-job-spec.md file.

**Benefits**

This provides a safe upgrade path for customers deploying the Gateway behind a Database Proxy that utilizes connection multiplexing (such as ProxySQL or HAProxy). Because proxy multiplexing breaks the MySQL GET_LOCK() session lock, this dedicated migration job allows the administrator to provide a direct JDBC URL to the single primary database writer. This completely bypasses the proxy for the duration of the schema upgrade, ensuring that the session lock functions perfectly and prevents deadlocks or schema corruption before the live cluster is updated.

**Drawbacks**

The current way to perform the db schema update and exit cleanly without starting gateway is just temporary.  A cleaner way to do this by modiying the entrypoint.sh in the gateway container will be done next.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

When database.migrationJob.enabled is set to true, the database.migrationJob.jdbcUrl parameter is strictly validated as mandatory via the Helm required function. This was intentionally designed to ensure administrators explicitly configure the proxy-bypass endpoint to avoid accidental deployment failures.


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

