### PR TITLE
[charts/portal] Add seaweedfs check when analytics/infra disabled 

### DIFF
--- a/charts/portal/templates/_helpers.tpl
+++ b/charts/portal/templates/_helpers.tpl
@@ -25,6 +25,18 @@ releases must explicitly set portal.seaweedFs.enabled=true when analytics is ena
 {{- end -}}
 
 {{/*
+Validate that portal.seaweedFs.enabled is false when neither portal.analytics.enabled
+nor portal.infrastructureManagement.enabled is true.
+SeaweedFS serves no purpose when both features are disabled — running it wastes
+resources.
+*/}}
+{{- define "portal.validateSeaweedFsUnused" -}}
+{{- if and .Values.portal.seaweedFs.enabled (not .Values.portal.analytics.enabled) (not .Values.portal.infrastructureManagement.enabled) -}}
+{{- fail "portal.seaweedFs.enabled=true requires portal.analytics.enabled=true or portal.infrastructureManagement.enabled=true. Disable seaweedFs when neither feature is active: --set portal.seaweedFs.enabled=false" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "portal.name" -}}

--- a/charts/portal/templates/portal-data/portal-data-config.yaml
+++ b/charts/portal/templates/portal-data/portal-data-config.yaml
@@ -2,6 +2,7 @@
 # AI assistance has been used to generate some or all contents of this file. That includes, but is not limited to, new code, modifying existing code, stylistic edits.
 {{- include "portal.validateInfrastructureManagement" . }}
 {{- include "portal.validateAnalyticsSeaweedFs" . }}
+{{- include "portal.validateSeaweedFsUnused" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -92,7 +92,7 @@ portal:
   # SeaweedFS object storage sub-chart gate. 
   # SeaweedFS should be enabled if infrastructureManagement or analytics enabled.
   seaweedFs:
-    enabled: false
+    enabled: true
   # Specify a Gateway v9.x license file via set portal.license.value
   # This bootstraps a license to apim
   # To renew a license toggle license.secretName and specify your new license with helm upgrade

--- a/charts/portal/values-production.yaml
+++ b/charts/portal/values-production.yaml
@@ -92,7 +92,7 @@ portal:
   # SeaweedFS object storage sub-chart gate. 
   # SeaweedFS should be enabled if infrastructureManagement or analytics enabled.
   seaweedFs:
-    enabled: true
+    enabled: false
   # Specify a Gateway v9.x license file via set portal.license.value
   # This bootstraps a license to apim
   # To renew a license toggle license.secretName and specify your new license with helm upgrade
@@ -1179,7 +1179,7 @@ kafka:
   kafka:
     # Number of Kafka broker replicas
     # Set to 3 for production deployments with intelligence enabled
-    replicaCount: 1
+    replicaCount: 3
 
     # Ordinals configuration (Kubernetes 1.27+)
     # Set start ordinal for StatefulSet pods

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -117,7 +117,7 @@ portal:
   # SeaweedFS object storage sub-chart gate.
   # SeaweedFS should be enabled if infrastructureManagement or analytics enabled.
   seaweedFs:
-    enabled: false
+    enabled: true
   # Please set analytics.replicaCount to a minimum of 2
     aggregation: false
   # Specify a Gateway v9.x license file via set portal.license.value

--- a/charts/portal/values.yaml
+++ b/charts/portal/values.yaml
@@ -117,7 +117,7 @@ portal:
   # SeaweedFS object storage sub-chart gate.
   # SeaweedFS should be enabled if infrastructureManagement or analytics enabled.
   seaweedFs:
-    enabled: true
+    enabled: false
   # Please set analytics.replicaCount to a minimum of 2
     aggregation: false
   # Specify a Gateway v9.x license file via set portal.license.value


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

