### PR TITLE
[charts/gateway] US1113865: Epic 1: OTK Docker Install Image — Pure Java Migration

### DIFF
--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -57,23 +57,23 @@ data:
   OTK_CASSANDRA_KEYSPACE: {{ required "Please fill in otk.database.cassandra.keyspace in values.yaml" .Values.otk.database.cassandra.keyspace | quote }}
   OTK_CASSANDRA_DRIVER_CONFIG: {{ default "na" .Values.otk.database.cassandra.driverConfig | toJson | b64enc| quote }}
   {{- end }}
-  OTK_DATABASE_PROPERTIES: {{ default "na" .Values.otk.database.properties | toJson | b64enc | quote }}
+  OTK_DATABASE_PROPERTIES: {{ default dict .Values.otk.database.properties | toJson | b64enc | quote }}
   {{- if or (eq .Values.otk.database.type "mysql") (eq .Values.otk.database.type "oracle") }}
   OTK_JDBC_DRIVER_CLASS: {{ required "Please fill in otk.database.sql.jdbcDriverClass in values.yaml" .Values.otk.database.sql.jdbcDriverClass | quote }}
-  OTK_DATABASE_CONN_PROPERTIES: {{ default "na" .Values.otk.database.sql.connectionProperties | toJson | b64enc | quote }}
+  OTK_DATABASE_CONN_PROPERTIES: {{ default dict .Values.otk.database.sql.connectionProperties | toJson | b64enc | quote }}
   {{- if .Values.otk.database.readOnlyConnection.enabled }}
   OTK_RO_DATABASE_CONNECTION_NAME: {{ required "Please fill in otk.database.readOnlyConnection.connectionName in values.yaml" .Values.otk.database.readOnlyConnection.connectionName | quote }}
   OTK_RO_JDBC_URL: {{ default .Values.otk.database.sql.jdbcURL .Values.otk.database.readOnlyConnection.jdbcURL | quote }}
   OTK_RO_JDBC_DRIVER_CLASS: {{ default .Values.otk.database.sql.jdbcDriverClass .Values.otk.database.readOnlyConnection.jdbcDriverClass | quote }}
-  OTK_RO_DATABASE_PROPERTIES: {{ default "na" .Values.otk.database.readOnlyConnection.properties | toJson | b64enc | quote }}
-  OTK_RO_DATABASE_CONN_PROPERTIES: {{ default "na" .Values.otk.database.readOnlyConnection.connectionProperties | toJson | b64enc | quote }}
+  OTK_RO_DATABASE_PROPERTIES: {{ default dict .Values.otk.database.readOnlyConnection.properties | toJson | b64enc | quote }}
+  OTK_RO_DATABASE_CONN_PROPERTIES: {{ default dict .Values.otk.database.readOnlyConnection.connectionProperties | toJson | b64enc | quote }}
   {{- end }}
   {{- if .Values.otk.database.clientReadConnection.enabled }}
   OTK_CLIENT_READ_DATABASE_CONNECTION_NAME: {{ required "Please fill in otk.database.clientReadConnection.connectionName in values.yaml" .Values.otk.database.clientReadConnection.connectionName | quote }}
   OTK_CLIENT_READ_JDBC_URL: {{ default .Values.otk.database.sql.jdbcURL .Values.otk.database.clientReadConnection.jdbcURL | quote }}
   OTK_CLIENT_READ_JDBC_DRIVER_CLASS: {{ default .Values.otk.database.sql.jdbcDriverClass .Values.otk.database.clientReadConnection.jdbcDriverClass | quote }}
-  OTK_CLIENT_READ_DATABASE_PROPERTIES: {{ default "na" .Values.otk.database.clientReadConnection.properties | toJson | b64enc | quote }}
-  OTK_CLIENT_READ_DATABASE_CONN_PROPERTIES: {{ default "na" .Values.otk.database.clientReadConnection.connectionProperties | toJson | b64enc | quote }}
+  OTK_CLIENT_READ_DATABASE_PROPERTIES: {{ default dict .Values.otk.database.clientReadConnection.properties | toJson | b64enc | quote }}
+  OTK_CLIENT_READ_DATABASE_CONN_PROPERTIES: {{ default dict .Values.otk.database.clientReadConnection.connectionProperties | toJson | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- if eq .Values.otk.database.type "oracle" }}


### PR DESCRIPTION
**Description of the change**

Fixed minor default values set by Helm charts. Passing empty JSON {}. instead of na. 

**Benefits**

The OTK install/upgrade image gets a well formed values. The JSON object will read the empty JSON {} & will not fail

**Drawbacks**

NA

**Applicable issues**

NA

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

