### PR TITLE
US1110452: Added Database SSL Params to support Secure Transport

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -186,10 +186,10 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `database.name`          | Database name | `ssg`  |
 | `database.type`          | Embedded database type (`h2` or empty for Derby). Only used when `database.enabled: false`. | `""`  |
 | `database.sslMode`          | Optional MySQL SSL mode (e.g. `VERIFY_CA`) for an external database. Only used when `disklessConfig.enabled: true` and `database.jdbcURL` carries no SSL parameters of its own. | `commented out` |
-| `database.sslTrustKeystoreUrl`          | Optional truststore URL (e.g. `file:/path/to/truststore.p12`) for verifying the MySQL server certificate | `commented out` |
+| `database.sslTrustKeystorePath`          | Optional truststore path (e.g. `/path/to/truststore.p12`) for verifying the MySQL server certificate. The `file:` prefix required by the Gateway is added automatically if omitted. | `commented out` |
 | `database.sslTrustKeystorePassword`          | Optional truststore password | `commented out` |
 | `database.sslTrustKeystoreType`          | Optional truststore type (e.g. `PKCS12`) | `commented out` |
-| `database.sslClientKeystoreUrl`          | Optional client keystore URL for mutual TLS with MySQL | `commented out` |
+| `database.sslClientKeystorePath`          | Optional client keystore path for mutual TLS with MySQL. The `file:` prefix required by the Gateway is added automatically if omitted. | `commented out` |
 | `database.sslClientKeystorePassword`          | Optional client keystore password | `commented out` |
 | `database.sslClientKeystoreType`          | Optional client keystore type (e.g. `PKCS12`) | `commented out` |
 | `database.sslExtraParams`          | Optional extra MySQL Connector/J parameters to append alongside the TLS settings above | `commented out` |
@@ -1475,7 +1475,7 @@ Configuring SSL/TLS: the following parameters can be added to enable secure comm
 jdbcURL: jdbc:mysql://myprimaryserver:3306,mysecondaryserver:3306/ssg?useSSL=true&requireSSL=true&verifyServerCertificate=false
 ```
 
-Alternatively, when `disklessConfig.enabled: true`, the same TLS settings can be provided as discrete `database.ssl*` fields instead of embedding them in `jdbcURL`. These map to the `SSG_DATABASE_MYSQL_*` environment variables, are all optional (commented out by default in values.yaml), and are ignored if `jdbcURL` already carries its own SSL parameters — an explicit `jdbcURL` always takes precedence:
+Alternatively, when `disklessConfig.enabled: true`, the same TLS settings can be provided as discrete `database.ssl*` fields instead of embedding them in `jdbcURL`. These map to the `SSG_DATABASE_MYSQL_*` environment variables, are all optional (commented out by default in values.yaml), and are ignored if `jdbcURL` already carries its own SSL parameters — an explicit `jdbcURL` always takes precedence. `sslTrustKeystorePath`/`sslClientKeystorePath` take a plain filesystem path — the chart adds the `file:` prefix the Gateway expects automatically (an already-prefixed value is also accepted, for backwards compatibility):
 
 ```yaml
 database:
@@ -1483,13 +1483,38 @@ database:
   create: false
   jdbcURL: jdbc:mysql://myprimaryserver:3306/ssg
   sslMode: "VERIFY_CA"
-  sslTrustKeystoreUrl: "file:/path/to/truststore.p12"
+  sslTrustKeystorePath: "/path/to/truststore.p12"
   sslTrustKeystorePassword: "changeit"
   sslTrustKeystoreType: "PKCS12"
-  sslClientKeystoreUrl: "file:/path/to/keystore.p12"
+  sslClientKeystorePath: "/path/to/keystore.p12"
   sslClientKeystorePassword: "changeit"
   sslClientKeystoreType: "PKCS12"
   sslExtraParams: ""
+```
+
+`sslTrustKeystorePath`/`sslClientKeystorePath` only tell the Gateway where to *look* for the keystore file inside the pod — the file itself still needs to be mounted. Use `customConfig.mounts` to mount an existing Secret (or ConfigMap) containing the keystore at that same path, keeping `mountPath` in sync with the `sslTrustKeystorePath`/`sslClientKeystorePath` value above:
+
+```yaml
+customConfig:
+  enabled: true
+  mounts:
+    - name: db-truststore-override
+      mountPath: /opt/docker/tls/truststore.p12
+      subPath: truststore.p12
+      secret:
+        name: mysql-truststore
+        item:
+          key: truststore.p12
+          path: truststore.p12
+```
+```yaml
+database:
+  sslTrustKeystorePath: "/opt/docker/tls/truststore.p12"
+```
+
+The referenced Secret (`mysql-truststore` above) must already exist in the release namespace, e.g.:
+```
+kubectl create secret generic mysql-truststore --from-file=truststore.p12=/path/to/truststore.p12
 ```
 
 In order the create the database on the remote server, the provided user in the username field must have write privilege on the database. See GRANT statement usage: https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -185,6 +185,14 @@ The following table lists the configurable parameters of the Gateway chart and t
 | `database.liquibaseLogLevel`          | Liquibase log level | `off`  |
 | `database.name`          | Database name | `ssg`  |
 | `database.type`          | Embedded database type (`h2` or empty for Derby). Only used when `database.enabled: false`. | `""`  |
+| `database.sslMode`          | Optional MySQL SSL mode (e.g. `VERIFY_CA`) for an external database. Only used when `disklessConfig.enabled: true` and `database.jdbcURL` carries no SSL parameters of its own. | `commented out` |
+| `database.sslTrustKeystoreUrl`          | Optional truststore URL (e.g. `file:/path/to/truststore.p12`) for verifying the MySQL server certificate | `commented out` |
+| `database.sslTrustKeystorePassword`          | Optional truststore password | `commented out` |
+| `database.sslTrustKeystoreType`          | Optional truststore type (e.g. `PKCS12`) | `commented out` |
+| `database.sslClientKeystoreUrl`          | Optional client keystore URL for mutual TLS with MySQL | `commented out` |
+| `database.sslClientKeystorePassword`          | Optional client keystore password | `commented out` |
+| `database.sslClientKeystoreType`          | Optional client keystore type (e.g. `PKCS12`) | `commented out` |
+| `database.sslExtraParams`          | Optional extra MySQL Connector/J parameters to append alongside the TLS settings above | `commented out` |
 | `tls.useSignedCertificates`          | Enable/Disable use of your own TLS Certificate, this ovverides the Gateway's defaultSSLKey | `false` |
 | `tls.existingSecretName`          | Existing Secret that contains TLS p12 container and pass, see values.yaml for what must be included | `commented out` |
 | `tls.key`          | p12 container - this can be set with --set-file tls.key=/path/to/tls.p12 | `nil`  |
@@ -1465,6 +1473,23 @@ Configuring SSL/TLS: the following parameters can be added to enable secure comm
 
 ```
 jdbcURL: jdbc:mysql://myprimaryserver:3306,mysecondaryserver:3306/ssg?useSSL=true&requireSSL=true&verifyServerCertificate=false
+```
+
+Alternatively, when `disklessConfig.enabled: true`, the same TLS settings can be provided as discrete `database.ssl*` fields instead of embedding them in `jdbcURL`. These map to the `SSG_DATABASE_MYSQL_*` environment variables, are all optional (commented out by default in values.yaml), and are ignored if `jdbcURL` already carries its own SSL parameters — an explicit `jdbcURL` always takes precedence:
+
+```yaml
+database:
+  enabled: true
+  create: false
+  jdbcURL: jdbc:mysql://myprimaryserver:3306/ssg
+  sslMode: "VERIFY_CA"
+  sslTrustKeystoreUrl: "file:/path/to/truststore.p12"
+  sslTrustKeystorePassword: "changeit"
+  sslTrustKeystoreType: "PKCS12"
+  sslClientKeystoreUrl: "file:/path/to/keystore.p12"
+  sslClientKeystorePassword: "changeit"
+  sslClientKeystoreType: "PKCS12"
+  sslExtraParams: ""
 ```
 
 In order the create the database on the remote server, the provided user in the username field must have write privilege on the database. See GRANT statement usage: https://dev.mysql.com/doc/refman/8.0/en/grant.html#grant-database-privileges

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1492,6 +1492,8 @@ database:
   sslExtraParams: ""
 ```
 
+`sslTrustKeystorePassword`/`sslClientKeystorePassword` are sensitive and, like `database.password`, can instead be supplied through [`existingGatewaySecretName`](#configuration) by including `SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD`/`SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD` in that Secret instead of setting the plaintext values above.
+
 `sslTrustKeystorePath`/`sslClientKeystorePath` only tell the Gateway where to *look* for the keystore file inside the pod — the file itself still needs to be mounted. Use `customConfig.mounts` to mount an existing Secret (or ConfigMap) containing the keystore at that same path, keeping `mountPath` in sync with the `sslTrustKeystorePath`/`sslClientKeystorePath` value above:
 
 ```yaml

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -8,9 +8,10 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 If you use Policy Manager, you will need to update to v11.2.0.
 
 ## 3.1.5 MySQL TLS Environment Variables
-- Added discrete `database.ssl*` values (`sslMode`, `sslTrustKeystoreUrl`, `sslTrustKeystorePassword`, `sslTrustKeystoreType`, `sslClientKeystoreUrl`, `sslClientKeystorePassword`, `sslClientKeystoreType`, `sslExtraParams`) as an alternative to embedding TLS parameters in `database.jdbcURL`.
+- Added discrete `database.ssl*` values (`sslMode`, `sslTrustKeystorePath`, `sslTrustKeystorePassword`, `sslTrustKeystoreType`, `sslClientKeystorePath`, `sslClientKeystorePassword`, `sslClientKeystoreType`, `sslExtraParams`) as an alternative to embedding TLS parameters in `database.jdbcURL`.
   - All are optional and commented out by default in values.yaml — leaving them unset preserves existing behaviour.
   - Only used when `disklessConfig.enabled: true`; mapped to the `SSG_DATABASE_MYSQL_*` environment variables.
+  - `sslTrustKeystorePath`/`sslClientKeystorePath` take a plain filesystem path — the chart adds the `file:` prefix the Gateway expects automatically (an already-prefixed value is also accepted).
   - Ignored when `database.jdbcURL` already carries its own SSL parameters — an explicit `jdbcURL` always takes precedence.
   - See [Database Configuration](./README.md#database-configuration) for details.
 

--- a/charts/gateway/release-notes.md
+++ b/charts/gateway/release-notes.md
@@ -7,6 +7,13 @@ The Layer7 API Gateway is now running with Java 21 with the release of v11.2.0.
 
 If you use Policy Manager, you will need to update to v11.2.0.
 
+## 3.1.5 MySQL TLS Environment Variables
+- Added discrete `database.ssl*` values (`sslMode`, `sslTrustKeystoreUrl`, `sslTrustKeystorePassword`, `sslTrustKeystoreType`, `sslClientKeystoreUrl`, `sslClientKeystorePassword`, `sslClientKeystoreType`, `sslExtraParams`) as an alternative to embedding TLS parameters in `database.jdbcURL`.
+  - All are optional and commented out by default in values.yaml — leaving them unset preserves existing behaviour.
+  - Only used when `disklessConfig.enabled: true`; mapped to the `SSG_DATABASE_MYSQL_*` environment variables.
+  - Ignored when `database.jdbcURL` already carries its own SSL parameters — an explicit `jdbcURL` always takes precedence.
+  - See [Database Configuration](./README.md#database-configuration) for details.
+
 ## 3.1.4 H2 Embedded Database Support
 - Added support for the H2 embedded database as an alternative to the default Derby embedded database.
   - Set `database.type: "h2"` in your values file to enable H2. Requires `database.enabled: false`.

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -85,6 +85,24 @@ Create java args to apply.
 {{- end -}}
 
 {{/*
+Normalize a MySQL keystore path (database.sslTrustKeystorePath / sslClientKeystorePath) into the
+"file:" URL form the Gateway's SSG_DATABASE_MYSQL_*_KEYSTORE_URL environment variables expect.
+Accepts either a plain filesystem path (e.g. /opt/docker/tls/truststore.p12) or an already-prefixed
+value (file:/opt/docker/tls/truststore.p12, for backwards compatibility) and always returns the
+"file:" form, so users are not required to know about or type the prefix themselves.
+*/}}
+{{- define "gateway.keystoreFilePath" -}}
+{{- $path := . -}}
+{{- if not (hasPrefix "file:" $path) -}}
+{{- if not (hasPrefix "/" $path) -}}
+{{- $path = printf "/%s" $path -}}
+{{- end -}}
+{{- $path = printf "file:%s" $path -}}
+{{- end -}}
+{{- $path -}}
+{{- end -}}
+
+{{/*
 Shared state client secret name
 */}}
 {{- define "sharedStateClientSecretName" }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -40,14 +40,14 @@ data:
     {{- if .Values.database.sslMode }}
   SSG_DATABASE_MYSQL_SSL_MODE: {{ .Values.database.sslMode | quote }}
     {{- end }}
-    {{- if .Values.database.sslTrustKeystoreUrl }}
-  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL: {{ .Values.database.sslTrustKeystoreUrl | quote }}
+    {{- if .Values.database.sslTrustKeystorePath }}
+  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL: {{ include "gateway.keystoreFilePath" .Values.database.sslTrustKeystorePath | quote }}
     {{- end }}
     {{- if .Values.database.sslTrustKeystoreType }}
   SSG_DATABASE_MYSQL_TRUST_KEYSTORE_TYPE: {{ .Values.database.sslTrustKeystoreType | quote }}
     {{- end }}
-    {{- if .Values.database.sslClientKeystoreUrl }}
-  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL: {{ .Values.database.sslClientKeystoreUrl | quote }}
+    {{- if .Values.database.sslClientKeystorePath }}
+  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL: {{ include "gateway.keystoreFilePath" .Values.database.sslClientKeystorePath | quote }}
     {{- end }}
     {{- if .Values.database.sslClientKeystoreType }}
   SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_TYPE: {{ .Values.database.sslClientKeystoreType | quote }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -37,6 +37,24 @@ data:
     {{- else }}
   SSG_DATABASE_JDBC_URL: {{ .Values.database.jdbcURL }}
     {{- end }}
+    {{- if .Values.database.sslMode }}
+  SSG_DATABASE_MYSQL_SSL_MODE: {{ .Values.database.sslMode | quote }}
+    {{- end }}
+    {{- if .Values.database.sslTrustKeystoreUrl }}
+  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL: {{ .Values.database.sslTrustKeystoreUrl | quote }}
+    {{- end }}
+    {{- if .Values.database.sslTrustKeystoreType }}
+  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_TYPE: {{ .Values.database.sslTrustKeystoreType | quote }}
+    {{- end }}
+    {{- if .Values.database.sslClientKeystoreUrl }}
+  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL: {{ .Values.database.sslClientKeystoreUrl | quote }}
+    {{- end }}
+    {{- if .Values.database.sslClientKeystoreType }}
+  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_TYPE: {{ .Values.database.sslClientKeystoreType | quote }}
+    {{- end }}
+    {{- if .Values.database.sslExtraParams }}
+  SSG_DATABASE_MYSQL_EXTRA_PARAMS: {{ .Values.database.sslExtraParams | quote }}
+    {{- end }}
   {{- end }}
   {{- if .Values.database.type }}
   SSG_DATABASE_TYPE: {{ .Values.database.type | lower | quote }}

--- a/charts/gateway/templates/db-migration-job.yaml
+++ b/charts/gateway/templates/db-migration-job.yaml
@@ -87,15 +87,18 @@ spec:
                    db-migration-secret.yaml) rather than the main release Secret, which Helm does not
                    update until after pre-upgrade hooks have run. These explicit env entries override
                    the same keys supplied via envFrom above. Conditions must stay in sync with
-                   db-migration-secret.yaml so this never references a Secret that was not created. */}}
-            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslTrustKeystorePassword }}
+                   db-migration-secret.yaml so this never references a Secret that was not created.
+                   When existingGatewaySecretName is set, db-migration-secret.yaml is not rendered at
+                   all -- that Secret is user-managed and already live, so envFrom above already has
+                   current values and these overrides must be skipped too. */}}
+            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslTrustKeystorePassword (not .Values.existingGatewaySecretName) }}
             - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "gateway.fullname" . }}-db-migration-secret
                   key: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD
             {{- end }}
-            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslClientKeystorePassword }}
+            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslClientKeystorePassword (not .Values.existingGatewaySecretName) }}
             - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/gateway/templates/db-migration-job.yaml
+++ b/charts/gateway/templates/db-migration-job.yaml
@@ -63,17 +63,17 @@ spec:
             - name: SSG_DATABASE_MYSQL_SSL_MODE
               value: {{ .Values.database.sslMode | quote }}
             {{- end }}
-            {{- if .Values.database.sslTrustKeystoreUrl }}
+            {{- if .Values.database.sslTrustKeystorePath }}
             - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL
-              value: {{ .Values.database.sslTrustKeystoreUrl | quote }}
+              value: {{ include "gateway.keystoreFilePath" .Values.database.sslTrustKeystorePath | quote }}
             {{- end }}
             {{- if .Values.database.sslTrustKeystoreType }}
             - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_TYPE
               value: {{ .Values.database.sslTrustKeystoreType | quote }}
             {{- end }}
-            {{- if .Values.database.sslClientKeystoreUrl }}
+            {{- if .Values.database.sslClientKeystorePath }}
             - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL
-              value: {{ .Values.database.sslClientKeystoreUrl | quote }}
+              value: {{ include "gateway.keystoreFilePath" .Values.database.sslClientKeystorePath | quote }}
             {{- end }}
             {{- if .Values.database.sslClientKeystoreType }}
             - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_TYPE

--- a/charts/gateway/templates/db-migration-job.yaml
+++ b/charts/gateway/templates/db-migration-job.yaml
@@ -59,6 +59,49 @@ spec:
             - name: SSG_DATABASE_JDBC_URL
               value: {{ .Values.database.jdbcURL | quote }}
             {{- end }}
+            {{- if .Values.database.sslMode }}
+            - name: SSG_DATABASE_MYSQL_SSL_MODE
+              value: {{ .Values.database.sslMode | quote }}
+            {{- end }}
+            {{- if .Values.database.sslTrustKeystoreUrl }}
+            - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL
+              value: {{ .Values.database.sslTrustKeystoreUrl | quote }}
+            {{- end }}
+            {{- if .Values.database.sslTrustKeystoreType }}
+            - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_TYPE
+              value: {{ .Values.database.sslTrustKeystoreType | quote }}
+            {{- end }}
+            {{- if .Values.database.sslClientKeystoreUrl }}
+            - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL
+              value: {{ .Values.database.sslClientKeystoreUrl | quote }}
+            {{- end }}
+            {{- if .Values.database.sslClientKeystoreType }}
+            - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_TYPE
+              value: {{ .Values.database.sslClientKeystoreType | quote }}
+            {{- end }}
+            {{- if .Values.database.sslExtraParams }}
+            - name: SSG_DATABASE_MYSQL_EXTRA_PARAMS
+              value: {{ .Values.database.sslExtraParams | quote }}
+            {{- end }}
+            {{- /* Keystore passwords come from a dedicated pre-upgrade hook Secret (see
+                   db-migration-secret.yaml) rather than the main release Secret, which Helm does not
+                   update until after pre-upgrade hooks have run. These explicit env entries override
+                   the same keys supplied via envFrom above. Conditions must stay in sync with
+                   db-migration-secret.yaml so this never references a Secret that was not created. */}}
+            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslTrustKeystorePassword }}
+            - name: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gateway.fullname" . }}-db-migration-secret
+                  key: SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD
+            {{- end }}
+            {{- if and .Values.database.enabled .Values.disklessConfig.enabled .Values.database.sslClientKeystorePassword }}
+            - name: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "gateway.fullname" . }}-db-migration-secret
+                  key: SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD
+            {{- end }}
             - name: EXTRA_JAVA_ARGS
               {{- if .Values.database.migrationJob.clearLocks }}
               value: "-Dgateway.db.schema-update.mode=liquibase-only-with-unlock"

--- a/charts/gateway/templates/db-migration-secret.yaml
+++ b/charts/gateway/templates/db-migration-secret.yaml
@@ -1,0 +1,46 @@
+{{- if and .Values.database.migrationJob.enabled .Values.database.enabled .Values.disklessConfig.enabled }}
+{{- if or .Values.database.sslTrustKeystorePassword .Values.database.sslClientKeystorePassword }}
+# Short-lived Secret holding the MySQL TLS keystore passwords for the pre-upgrade db migration Job.
+#
+# Why this exists separately from templates/secret.yaml: the main release Secret is a normal
+# (non-hook) resource, so Helm applies it in the main upgrade phase -- AFTER pre-upgrade hooks have
+# already run. A keystore password introduced in the same `helm upgrade` that also enables
+# database.migrationJob would therefore not be visible to the Job, which reads the Secret live at
+# pod start via `envFrom: secretRef` (the same staleness that affected database.sslMode before it
+# was rendered directly into the Job's env). This Secret is a pre-upgrade hook at a lower
+# hook-weight than the Job (-10 vs the Job's -5), so it is guaranteed to exist with this upgrade's
+# values before the Job pod starts.
+#
+# The main release Secret is deliberately left untouched (it stays tracked in the release manifest
+# and is never deleted/recreated mid-upgrade, so the Gateway Deployment that depends on it is
+# unaffected). The two password keys are therefore duplicated for the duration of the upgrade;
+# the hook-succeeded delete policy removes this copy once the migration Job completes.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "gateway.fullname" . }}-db-migration-secret
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- range $key, $val := .Values.additionalAnnotations }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+  labels:
+    app: {{ template "gateway.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $val := .Values.additionalLabels }}
+    {{ $key }}: "{{ $val }}"
+    {{- end }}
+type: Opaque
+data:
+  {{- if .Values.database.sslTrustKeystorePassword }}
+  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD: {{ .Values.database.sslTrustKeystorePassword | b64enc }}
+  {{- end }}
+  {{- if .Values.database.sslClientKeystorePassword }}
+  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD: {{ .Values.database.sslClientKeystorePassword | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gateway/templates/db-migration-secret.yaml
+++ b/charts/gateway/templates/db-migration-secret.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.database.migrationJob.enabled .Values.database.enabled .Values.disklessConfig.enabled }}
+{{- if not .Values.existingGatewaySecretName }}
 {{- if or .Values.database.sslTrustKeystorePassword .Values.database.sslClientKeystorePassword }}
 # Short-lived Secret holding the MySQL TLS keystore passwords for the pre-upgrade db migration Job.
 #
@@ -10,6 +11,11 @@
 # was rendered directly into the Job's env). This Secret is a pre-upgrade hook at a lower
 # hook-weight than the Job (-10 vs the Job's -5), so it is guaranteed to exist with this upgrade's
 # values before the Job pod starts.
+#
+# This staleness only applies to the chart-created Secret, which Helm itself applies late. When
+# existingGatewaySecretName is set, that Secret is user-managed and already live before the
+# upgrade starts, so the Job's envFrom (which resolves to existingGatewaySecretName, see
+# gateway.secretName) already has current values and this hook Secret is skipped entirely.
 #
 # The main release Secret is deliberately left untouched (it stays tracked in the release manifest
 # and is never deleted/recreated mid-upgrade, so the Gateway Deployment that depends on it is
@@ -42,5 +48,6 @@ data:
   {{- if .Values.database.sslClientKeystorePassword }}
   SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD: {{ .Values.database.sslClientKeystorePassword | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -28,6 +28,12 @@ data:
   {{ if .Values.database.enabled }}
   SSG_DATABASE_USER: {{.Values.database.username | b64enc }}
   SSG_DATABASE_PASSWORD:  {{.Values.database.password | b64enc }}
+  {{- if .Values.database.sslTrustKeystorePassword }}
+  SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD: {{ .Values.database.sslTrustKeystorePassword | b64enc }}
+  {{- end }}
+  {{- if .Values.database.sslClientKeystorePassword }}
+  SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD: {{ .Values.database.sslClientKeystorePassword | b64enc }}
+  {{- end }}
   {{ end }}
 {{- end }}
 {{ if .Values.additionalSecret }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -668,6 +668,18 @@ database:
   # Set to "h2" to use the H2 embedded database. Requires database.enabled: false.
   # type: "h2"
   type: ""
+  # Optional MySQL TLS/SSL settings for connecting to an external MySQL database, used only when
+  # disklessConfig.enabled: true. These map to the SSG_DATABASE_MYSQL_* environment variables and take
+  # effect only when database.jdbcURL does not already carry SSL parameters of its own; an explicit
+  # jdbcURL always takes precedence. See "Database Configuration" for details on precedence.
+  # sslMode: "VERIFY_CA"
+  # sslTrustKeystoreUrl: "file:/path/to/truststore.p12"
+  # sslTrustKeystorePassword: "changeit"
+  # sslTrustKeystoreType: "PKCS12"
+  # sslClientKeystoreUrl: "file:/path/to/keystore.p12"
+  # sslClientKeystorePassword: "changeit"
+  # sslClientKeystoreType: "PKCS12"
+  # sslExtraParams: ""
 
 ## If loading a TLS Key/Pair
 # This key will become the default ssl key. Can only have one.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -626,6 +626,9 @@ config:
 ## If using a Database
   # SSG_DATABASE_USER
   # SSG_DATABASE_PASSWORD
+## If using database.ssl* to connect to an external MySQL Database (disklessConfig.enabled: true)
+  # SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD
+  # SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD
 
 # Cluster Hostname
 clusterHostname: my.localdomain

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -673,10 +673,13 @@ database:
   # effect only when database.jdbcURL does not already carry SSL parameters of its own; an explicit
   # jdbcURL always takes precedence. See "Database Configuration" for details on precedence.
   # sslMode: "VERIFY_CA"
-  # sslTrustKeystoreUrl: "file:/path/to/truststore.p12"
+  # A plain filesystem path is fine here -- the chart adds the required "file:" prefix
+  # automatically if it's missing. An already-prefixed value (file:/path/to/truststore.p12) is
+  # also accepted, for backwards compatibility.
+  # sslTrustKeystorePath: "/path/to/truststore.p12"
   # sslTrustKeystorePassword: "changeit"
   # sslTrustKeystoreType: "PKCS12"
-  # sslClientKeystoreUrl: "file:/path/to/keystore.p12"
+  # sslClientKeystorePath: "/path/to/keystore.p12"
   # sslClientKeystorePassword: "changeit"
   # sslClientKeystoreType: "PKCS12"
   # sslExtraParams: ""


### PR DESCRIPTION
**Description of the change**

### MySQL Database TLS Configuration (`database.ssl*` Helm values)

The Gateway Helm chart (`apim-charts`, `charts/gateway`) exposes the same MySQL TLS capability as discrete
values under `database:`. These map directly to the `SSG_DATABASE_MYSQL_*` environment variables described
above and are rendered into the release's ConfigMap/Secret — set them instead of hand-editing `node.properties`
or environment variables when deploying via Helm.

| Value | Maps to | Description |
|---|---|---|
| `database.sslMode` | `SSG_DATABASE_MYSQL_SSL_MODE` | `DISABLED`, `PREFERRED`, `REQUIRED`, `VERIFY_CA`, or `VERIFY_IDENTITY`. Unset = no TLS (default, unchanged behavior). |
| `database.sslTrustKeystoreUrl` | `SSG_DATABASE_MYSQL_TRUST_KEYSTORE_URL` | URL of the truststore used to validate the MySQL server certificate. Required for `VERIFY_CA`/`VERIFY_IDENTITY`. Must be a `file:` path that actually exists inside the pod — see "With volume mount" below. |
| `database.sslTrustKeystorePassword` | `SSG_DATABASE_MYSQL_TRUST_KEYSTORE_PASSWORD` | Password for the trust keystore. Rendered into the release Secret, base64-encoded — never plaintext in `kubectl get secret -o yaml`, and masked as `***MASKED***` in pod logs. |
| `database.sslTrustKeystoreType` | `SSG_DATABASE_MYSQL_TRUST_KEYSTORE_TYPE` | e.g. `JKS`, `PKCS12`. |
| `database.sslClientKeystoreUrl` | `SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_URL` | URL of the client keystore for mutual TLS. Same file-delivery requirement as the trust keystore. |
| `database.sslClientKeystorePassword` | `SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_PASSWORD` | Password for the client keystore. Same Secret/masking behavior as the trust keystore password. |
| `database.sslClientKeystoreType` | `SSG_DATABASE_MYSQL_CLIENT_KEYSTORE_TYPE` | e.g. `JKS`, `PKCS12`. |
| `database.sslExtraParams` | `SSG_DATABASE_MYSQL_EXTRA_PARAMS` | Additional raw JDBC parameters, appended as-is. |

`database.jdbcURL` must point at the external MySQL server (`database.create: false`) with no SSL query
parameters of its own — an explicit `sslMode`/`useSSL` in `jdbcURL` always takes precedence over these discrete
values, same precedence rule as the container/`node.properties` forms above.

#### Example: with volume mount — `sslMode=VERIFY_CA` with a truststore

Use this when you need to validate the server certificate against a specific CA. The truststore **file** must
exist inside the pod at the path `sslTrustKeystoreUrl` points to — setting the value alone is not enough, since
nothing writes the file there by itself. Deliver it as a Kubernetes Secret and mount it with `customConfig`,
the chart's supported mechanism for placing arbitrary ConfigMap/Secret content at specific paths on the Gateway
container (also used for things like a Redis TLS cert — see the "Mount ConfigMap/Secret to Specific Paths"
section of the GKE deployment guide).

1. Create the Secret from your truststore file:
   ```bash
   kubectl create secret generic mysql-truststore --from-file=truststore.p12=./truststore.p12
   ```

2. Reference it in your values file:
   ```yaml
   database:
     enabled: true
     create: false
     jdbcURL: "jdbc:mysql://<host>:3306/<database>"
     username: gateway
     password: <password>
     sslMode: "VERIFY_CA"
     sslTrustKeystoreUrl: "file:/opt/docker/tls/truststore.p12"
     sslTrustKeystorePassword: "changeit"
     sslTrustKeystoreType: "PKCS12"
   
   customConfig:
     enabled: true
     mounts:
       - name: db-truststore-override
         mountPath: /opt/docker/tls/truststore.p12
         subPath: truststore.p12
         secret:
           name: mysql-truststore
           item:
             key: truststore.p12
             path: truststore.p12
   ```

3. `helm install`/`helm upgrade` as usual. The password you set in `sslTrustKeystorePassword` must match the
   actual password the truststore file was created with — a mismatch here fails silently at the driver level and
   just looks like a generic "Timed out while waiting for database to come up" in the logs, not a clear
   credential error.

For mutual TLS (client certificate authentication), add a second `customConfig.mounts` entry for the client
keystore and set `sslClientKeystoreUrl`/`sslClientKeystorePassword`/`sslClientKeystoreType` the same way.

**Benefits**

MySQL SSL Enabled 

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

