### PR TITLE
fixed logging error of TLS logging

### DIFF
--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -216,6 +216,7 @@ config:
     - -Djava.util.logging.config.file=/opt/SecureSpan/Gateway/node/default/etc/conf/log-override.properties
     - -Dcom.l7tech.server.pkix.useDefaultTrustAnchors=true
     - -Dcom.l7tech.security.ssl.hostAllowWildcard=true
+    - --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
     # - -Djava.net.preferIPv4Stack=false
     # - -Djava.net.preferIPv6Addresses=true
   log:


### PR DESCRIPTION
**Description of the change**

Getting error {"message":"TLS negotiated named group is unavailable: deep reflection into sun.security.ssl is not permitted by this JVM. } To fix this added Java args on values.yaml

**Benefits**

Not getting error

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

