### PR TITLE
[charts/gateway] US1115841: Helm Chart Changes

### DIFF
--- a/charts/gateway/production-values.yaml
+++ b/charts/gateway/production-values.yaml
@@ -848,6 +848,14 @@ otk:
   # List of comma separated sub solution Kits to install or upgrade.
   # subSolutionKitNames:
 
+  # When enabled, OTK DB/admin credentials are delivered to the otk-install and otk-db-upgrade
+  # Jobs via a mounted file per secret key (under otk.secretsMountPath) instead of envFrom:
+  # secretRef, so `kubectl exec <pod> -- env` / `kubectl describe pod` never expose the values
+  # in cleartext. Requires an otk-install/otk-db-upgrade image built with OtkSecrets.read()'s
+  # mount-first fallback (see F166450 Phase 1, docker/install repo).
+  mountBasedSecrets:
+    enabled: true
+
   customizations:
 
     # This mounts one or more bundles that exist as secrets or configmaps in your Kubernetes Cluster.

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -284,6 +284,16 @@ Define OTK Image Pull Secret Name
 {{- end -}}
 
 {{/*
+ Fixed mount root for OTK secret files when otk.mountBasedSecrets.enabled is true.
+ Mirrors Gateway's own disklessConfig fixed-path convention: one hardcoded path, no
+ separate "which path" value. Each mounted file's basename matches the env var name
+ it replaces, so app code (OtkSecrets.read(name)) needs no path-construction logic.
+ */}}
+{{- define "otk.secretsMountPath" -}}
+/opt/SecureSpan/Gateway/node/default/etc/conf/otk/secrets
+{{- end -}}
+
+{{/*
  Define OTK install image pullSecret
  */}}
 {{- define "otk.imagePullSecret" -}}

--- a/charts/gateway/templates/otk-db-upgrade-job.yaml
+++ b/charts/gateway/templates/otk-db-upgrade-job.yaml
@@ -55,9 +55,35 @@ spec:
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/otk/jks
               readOnly: true
           {{- end }}
+          {{- if .Values.otk.mountBasedSecrets.enabled }}
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_USERNAME
+              subPath: OTK_DATABASE_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_PASSWORD
+              subPath: OTK_DATABASE_PASSWORD
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_DDL_USERNAME
+              subPath: OTK_DATABASE_DDL_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_DDL_PASSWORD
+              subPath: OTK_DATABASE_DDL_PASSWORD
+              readOnly: true
+            {{- if and (eq .Values.otk.database.type "oracle") (.Values.otk.database.sql.oracleSsl.enabled) .Values.otk.database.sql.oracleSsl.trustStorePassword }}
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_ORACLE_TRUST_STORE_PASSWORD
+              subPath: OTK_ORACLE_TRUST_STORE_PASSWORD
+              readOnly: true
+            {{- end }}
+          {{- end }}
           envFrom:
+          {{- if not .Values.otk.mountBasedSecrets.enabled }}
             - secretRef:
                 name: {{ template "otk.dbSecretName" . }}
+          {{- end }}
           env:
            - name: OTK_TYPE
              value: {{ template "otk-install-type" .}}
@@ -101,6 +127,11 @@ spec:
         - name: {{ template "gateway.fullname" . }}-otk-secret-jks
           secret:
             secretName: {{ .Values.otk.database.sql.oracleTruststore.name }}
+        {{- end }}
+        {{- if .Values.otk.mountBasedSecrets.enabled }}
+        - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+          secret:
+            secretName: {{ template "otk.dbSecretName" . }}
         {{- end }}
       {{- if or (.Values.imagePullSecret.enabled) (.Values.otk.job.imagePullSecret.enabled) }}
       imagePullSecrets:

--- a/charts/gateway/templates/otk-install-job.yaml
+++ b/charts/gateway/templates/otk-install-job.yaml
@@ -62,9 +62,64 @@ spec:
             {{ end }}
           {{- end }}
           {{- end }}
+          {{- if .Values.otk.mountBasedSecrets.enabled }}
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_USERNAME
+              subPath: OTK_DATABASE_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_PASSWORD
+              subPath: OTK_DATABASE_PASSWORD
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_DDL_USERNAME
+              subPath: OTK_DATABASE_DDL_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_DATABASE_DDL_PASSWORD
+              subPath: OTK_DATABASE_DDL_PASSWORD
+              readOnly: true
+            {{- if and (eq .Values.otk.database.type "oracle") (.Values.otk.database.sql.oracleSsl.enabled) .Values.otk.database.sql.oracleSsl.trustStorePassword }}
+            - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_ORACLE_TRUST_STORE_PASSWORD
+              subPath: OTK_ORACLE_TRUST_STORE_PASSWORD
+              readOnly: true
+            {{- end }}
+            {{- if .Values.disklessConfig.enabled }}
+            - name: {{ template "gateway.fullname" . }}-gateway-admin-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/SSG_ADMIN_USERNAME
+              subPath: SSG_ADMIN_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-gateway-admin-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/SSG_ADMIN_PASSWORD
+              subPath: SSG_ADMIN_PASSWORD
+              readOnly: true
+            {{- end }}
+            {{- if and (.Values.otk.database.readOnlyConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+            - name: {{ template "gateway.fullname" . }}-otk-ro-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_RO_DATABASE_USERNAME
+              subPath: OTK_RO_DATABASE_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-ro-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_RO_DATABASE_PASSWORD
+              subPath: OTK_RO_DATABASE_PASSWORD
+              readOnly: true
+            {{- end }}
+            {{- if and (.Values.otk.database.clientReadConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+            - name: {{ template "gateway.fullname" . }}-otk-cr-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_CLIENT_READ_DATABASE_USERNAME
+              subPath: OTK_CLIENT_READ_DATABASE_USERNAME
+              readOnly: true
+            - name: {{ template "gateway.fullname" . }}-otk-cr-db-secret-mount
+              mountPath: {{ include "otk.secretsMountPath" . }}/OTK_CLIENT_READ_DATABASE_PASSWORD
+              subPath: OTK_CLIENT_READ_DATABASE_PASSWORD
+              readOnly: true
+            {{- end }}
+          {{- end }}
 
           resources: {{- toYaml .Values.otk.job.resources | nindent 12 }}
           envFrom:
+          {{- if not .Values.otk.mountBasedSecrets.enabled }}
             - secretRef:
                 name: {{ template "otk.dbSecretName" . }}
             - secretRef:
@@ -77,6 +132,7 @@ spec:
             - secretRef:
                 name: {{ template "otk.dbSecretName.clientRead" . }}
             {{ end }}
+          {{- end }}
             - configMapRef:
                 name: {{ template "gateway.fullname" . }}-otk-install-configmap
 
@@ -101,6 +157,26 @@ spec:
           secret:
             secretName: {{ .name }}
           {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.otk.mountBasedSecrets.enabled }}
+        - name: {{ template "gateway.fullname" . }}-otk-db-secret-mount
+          secret:
+            secretName: {{ template "otk.dbSecretName" . }}
+        {{- if .Values.disklessConfig.enabled }}
+        - name: {{ template "gateway.fullname" . }}-gateway-admin-secret-mount
+          secret:
+            secretName: {{ template "gateway.secretName" . }}
+        {{- end }}
+        {{- if and (.Values.otk.database.readOnlyConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+        - name: {{ template "gateway.fullname" . }}-otk-ro-db-secret-mount
+          secret:
+            secretName: {{ template "otk.dbSecretName.readOnly" . }}
+        {{- end }}
+        {{- if and (.Values.otk.database.clientReadConnection.enabled) (ne .Values.otk.database.type "cassandra") }}
+        - name: {{ template "gateway.fullname" . }}-otk-cr-db-secret-mount
+          secret:
+            secretName: {{ template "otk.dbSecretName.clientRead" . }}
         {{- end }}
         {{- end }}
 

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -845,6 +845,15 @@ otk:
   # List of comma separated sub solution Kits to install or upgrade.
   # subSolutionKitNames:
 
+  # When enabled, OTK DB/admin credentials are delivered to the otk-install and otk-db-upgrade
+  # Jobs via a mounted file per secret key (under otk.secretsMountPath) instead of envFrom:
+  # secretRef, so `kubectl exec <pod> -- env` / `kubectl describe pod` never expose the values
+  # in cleartext. Default false = current envFrom behavior, unchanged. Requires an
+  # otk-install/otk-db-upgrade image built with OtkSecrets.read()'s mount-first fallback
+  # (see F166450 Phase 1, docker/install repo).
+  mountBasedSecrets:
+    enabled: false
+
   customizations:
 
     # This mounts one or more bundles that exist as secrets or configmaps in your Kubernetes Cluster.


### PR DESCRIPTION
**Description of the change**

Helm Chart Changes to support diskless config

**Benefits**
Prevent Kubernetes commands from presenting output secrets info from the console.  

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [x] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

