### PR TITLE
[charts/gateway] Update otk-install-configmap.yaml

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "11.2.2"
 description: This Helm Chart deploys the Layer7 Gateway in Kubernetes.
 name: gateway
-version: 3.1.3
+version: 3.1.4
 type: application
 home: https://github.com/CAAPIM/apim-charts
 maintainers:

--- a/charts/gateway/templates/otk-install-configmap.yaml
+++ b/charts/gateway/templates/otk-install-configmap.yaml
@@ -88,7 +88,7 @@ data:
   {{- end }}
   {{- if eq .Values.otk.database.type "mysql" }}
   {{- if (.Values.otk.database.useDemoDb)}}
-  OTK_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ default "otk_db" .Values.otk.database.sql.databaseName }}
+  OTK_JDBC_URL: jdbc:mysql://{{ template "gateway.fullname" . }}-mysql:3306/{{ default "otk_db" .Values.otk.database.sql.databaseName }}
   {{- else }}
   OTK_JDBC_URL: {{ required "Please fill in otk.database.sql.jdbcURL in values.yaml" .Values.otk.database.sql.jdbcURL | quote }}
   {{- end }}


### PR DESCRIPTION
Correct OTK_JDBC_URL when `useDemoDB=true`

**Description of the change**

Changed `OTK_JDBC_URL` template to use `{{ template "gateway.fullname" . }}` (same used to set `SSG_DATABASE_JDBC_URL`)

**Benefits**

Correct JDBC URL in `otk-install` ConfigMap when using 

**Drawbacks**

None

**Applicable issues**

  - fixes #539

**Additional information**

No `unstable` branch found as documented in [CONTRIBUTING.md](https://github.com/CAAPIM/apim-charts/blob/stable/CONTRIBUTING.md), PR opened against `stable`

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. `[charts/gateway]`)


